### PR TITLE
Improve CI

### DIFF
--- a/.github/workflows/CommonLib.yml
+++ b/.github/workflows/CommonLib.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
   release:
   
+concurrency:
+  group: commonlib-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: ${{ matrix.config.name }}
@@ -62,7 +66,7 @@ jobs:
             clang_format: "OFF",
           }
         - {
-            name: "ubuntu-gcc-asan",
+            name: "ubuntu-gcc-ubalsan",
             os: ubuntu-latest,
             build_type: "Debug",
             cc: "gcc",
@@ -70,24 +74,9 @@ jobs:
             generators: "Ninja",
             ccache: "ON",
             asan: "ON",
-            lsan: "OFF",
-            tsan: "OFF",
-            ubsan: "OFF",
-            code_coverage: "OFF",
-            clang_format: "OFF",
-          }
-        - {
-            name: "ubuntu-gcc-lsan",
-            os: ubuntu-latest,
-            build_type: "Debug",
-            cc: "gcc",
-            cxx: "g++",
-            generators: "Ninja",
-            ccache: "ON",
-            asan: "OFF",
             lsan: "ON",
             tsan: "OFF",
-            ubsan: "OFF",
+            ubsan: "ON",
             code_coverage: "OFF",
             clang_format: "OFF",
           }
@@ -103,21 +92,6 @@ jobs:
             lsan: "OFF",
             tsan: "ON",
             ubsan: "OFF",
-            code_coverage: "OFF",
-            clang_format: "OFF",
-          }
-        - {
-            name: "ubuntu-gcc-ubsan",
-            os: ubuntu-latest,
-            build_type: "Debug",
-            cc: "gcc",
-            cxx: "g++",
-            generators: "Ninja",
-            ccache: "ON",
-            asan: "OFF",
-            lsan: "OFF",
-            tsan: "OFF",
-            ubsan: "ON",
             code_coverage: "OFF",
             clang_format: "OFF",
           }
@@ -167,7 +141,7 @@ jobs:
         if: startsWith(matrix.config.ccache, 'ON')
         uses: hendrikmuhs/ccache-action@v1
         with:
-          key: ${{ matrix.os }}-${{ matrix.build_type }}
+          key: ${{ matrix.config.os }}-${{ matrix.build_type }}
           max-size: 500M
 
       - name: CPM Cache
@@ -175,9 +149,9 @@ jobs:
         uses: actions/cache@v2
         with:
           path: $GITHUB_WORKSPACE/.cpmcache
-          key: ${{ matrix.os }}-cpm-${{ hashFiles('**/') }}
+          key: ${{ matrix.config.os }}-cpm-${{ hashFiles('**/') }}
           restore-keys: |
-            ${{ matrix.os }}-cpm-
+            ${{ matrix.config.os }}-cpm-
 
       - name: Add clang path to $PATH env on Windows
         shell: bash
@@ -351,123 +325,3 @@ jobs:
           asset_path: ./${{ matrix.config.name }}.7z
           asset_name: ${{ matrix.config.name }}.7z.zip
           asset_content_type: application/zip
-
-  clang-format:
-    name: clang-format
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: true
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Install dependencies on ubuntu
-        run: |
-          sudo apt-get update --fix-missing
-          sudo apt-get install ninja-build
-          sudo apt-get install clang-format
-          sudo apt-get install libgles2-mesa-dev
-          ninja --version
-          cmake --version
-          gcc --version
-          clang --version
-          clang-format --version
-
-      - name: Configure
-        shell: bash
-        run: |
-          export CC=clang
-          export CXX=clang++
-          cmake \
-            -S CommonLib \
-            -B CommonLib/build \
-            -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
-            -DCOMMONLIB_CI=ON \
-            -DCOMMONLIB_CLANG_FORMAT_CHECK=ON \
-            -G "Ninja"
-
-      - name: Check
-        shell: bash
-        run: | 
-          export CC=clang
-          export CXX=clang++
-          cmake --build CommonLib/build --target commonlib_clang_format_check
-
-  clang-tidy:
-    name: clang-tidy
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: true
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Install dependencies on ubuntu
-        run: |
-          sudo apt-get update --fix-missing
-          sudo apt-get install ninja-build
-          sudo apt-get install clang-tidy
-          sudo apt-get install libgles2-mesa-dev
-          ninja --version
-          cmake --version
-          gcc --version
-          clang --version
-          clang-tidy --version
-
-      - name: Configure
-        shell: bash
-        run: |
-          export CC=clang
-          export CXX=clang++
-          cmake \
-            -S CommonLib \
-            -B CommonLib/build \
-            -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
-            -DCOMMONLIB_CI=ON \
-            -DCOMMONLIB_CLANG_TIDY_CHECK=ON \
-            -G "Ninja"
-
-      - name: Check
-        shell: bash
-        run: | 
-          export CC=clang
-          export CXX=clang++
-          cmake --build CommonLib/build --target commonlib_clang_tidy_check
-
-  cppcheck:
-    name: cppcheck
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: true
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Install dependencies on ubuntu
-        run: |
-          sudo apt-get update --fix-missing
-          sudo apt-get install ninja-build
-          sudo apt-get install cppcheck
-          sudo apt-get install libgles2-mesa-dev
-          ninja --version
-          cmake --version
-          gcc --version
-          clang --version
-          cppcheck --version
-
-      - name: Configure
-        shell: bash
-        run: |
-          export CC=clang
-          export CXX=clang++
-          cmake \
-            -S CommonLib \
-            -B CommonLib/build \
-            -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
-            -DCOMMONLIB_CI=ON \
-            -DCOMMONLIB_CPPCHECK=ON \
-            -G "Ninja"
-
-      - name: Check
-        shell: bash
-        run: | 
-          export CC=clang
-          export CXX=clang++
-          cmake --build CommonLib/build --target commonlib_cppcheck

--- a/.github/workflows/Linting.yml
+++ b/.github/workflows/Linting.yml
@@ -1,0 +1,101 @@
+name: Linting
+
+on:
+  push:
+  release:
+
+concurrency:
+  group: linting-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  commonlib-linting:
+    name: ${{ matrix.config.name }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+        - {
+            name: "commonlib-lint",
+            library_title: "CommonLib",
+            library_caps: "COMMONLIB",
+            library_lower: "commonlib",
+          }
+        - {
+            name: "myapp-lint",
+            library_title: "MyApp",
+            library_caps: "MYAPP",
+            library_lower: "myapp",
+          }
+        - {
+            name: "mylib-lint",
+            library_title: "MyLib",
+            library_caps: "MYLIB",
+            library_lower: "mylib",
+          }
+    steps:
+      - uses: actions/checkout@v2
+      
+      - name: CPM Cache
+        id: cache-cpm
+        uses: actions/cache@v2
+        with:
+          path: $GITHUB_WORKSPACE/.cpmcache
+          key: ${{ matrix.config.os }}-cpm-${{ hashFiles('**/') }}
+          restore-keys: |
+            ${{ matrix.config.os }}-cpm-
+
+      - name: Install dependencies on ubuntu
+        run: |
+          sudo apt-get update --fix-missing
+          sudo apt-get install ninja-build
+          sudo apt-get install clang-format
+          sudo apt-get install clang-tidy
+          sudo apt-get install cppcheck
+          sudo apt-get install libgles2-mesa-dev
+          ninja --version
+          cmake --version
+          gcc --version
+          clang --version
+          clang-format --version
+          clang-tidy --version
+          cppcheck --version
+
+      - name: Configure
+        shell: bash
+        run: |
+          export CC=clang
+          export CXX=clang++
+          cmake \
+            -S ${{ matrix.config.library_title }} \
+            -B ${{ matrix.config.library_title }}/build \
+            -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
+            -D${{ matrix.config.library_caps }}_CI=ON \
+            -D${{ matrix.config.library_caps }}_CLANG_FORMAT_CHECK=ON \
+            -D${{ matrix.config.library_caps }}_CLANG_TIDY_CHECK=ON \
+            -D${{ matrix.config.library_caps }}_CPPCHECK=ON \
+            -G "Ninja"
+
+      - name: clang-format
+        shell: bash
+        run: | 
+          export CC=clang
+          export CXX=clang++
+          cmake --build ${{ matrix.config.library_title }}/build --target ${{ matrix.config.library_lower }}_clang_format_check
+
+      - name: clang-tidy
+        shell: bash
+        if: always()
+        run: | 
+          export CC=clang
+          export CXX=clang++
+          cmake --build ${{ matrix.config.library_title }}/build --target ${{ matrix.config.library_lower }}_clang_tidy_check
+
+      - name: cppcheck
+        shell: bash
+        if: always()
+        run: | 
+          export CC=clang
+          export CXX=clang++
+          cmake --build ${{ matrix.config.library_title }}/build --target ${{ matrix.config.library_lower }}_cppcheck

--- a/.github/workflows/MyApp.yml
+++ b/.github/workflows/MyApp.yml
@@ -3,7 +3,11 @@ name: MyApp
 on:
   pull_request:
   release:
-  
+
+concurrency:
+  group: myapp-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: ${{ matrix.config.name }}
@@ -73,7 +77,7 @@ jobs:
             clang_format: "OFF",
           }
         - {
-            name: "ubuntu-gcc-asan",
+            name: "ubuntu-gcc-ubalsan",
             os: ubuntu-latest,
             build_type: "Debug",
             cc: "gcc",
@@ -81,24 +85,9 @@ jobs:
             generators: "Ninja",
             ccache: "ON",
             asan: "ON",
-            lsan: "OFF",
-            tsan: "OFF",
-            ubsan: "OFF",
-            code_coverage: "OFF",
-            clang_format: "OFF",
-          }
-        - {
-            name: "ubuntu-gcc-lsan",
-            os: ubuntu-latest,
-            build_type: "Debug",
-            cc: "gcc",
-            cxx: "g++",
-            generators: "Ninja",
-            ccache: "ON",
-            asan: "OFF",
             lsan: "ON",
             tsan: "OFF",
-            ubsan: "OFF",
+            ubsan: "ON",
             code_coverage: "OFF",
             clang_format: "OFF",
           }
@@ -114,21 +103,6 @@ jobs:
             lsan: "OFF",
             tsan: "ON",
             ubsan: "OFF",
-            code_coverage: "OFF",
-            clang_format: "OFF",
-          }
-        - {
-            name: "ubuntu-gcc-ubsan",
-            os: ubuntu-latest,
-            build_type: "Debug",
-            cc: "gcc",
-            cxx: "g++",
-            generators: "Ninja",
-            ccache: "ON",
-            asan: "OFF",
-            lsan: "OFF",
-            tsan: "OFF",
-            ubsan: "ON",
             code_coverage: "OFF",
             clang_format: "OFF",
           }
@@ -178,7 +152,7 @@ jobs:
         if: startsWith(matrix.config.ccache, 'ON')
         uses: hendrikmuhs/ccache-action@v1
         with:
-          key: ${{ matrix.os }}-${{ matrix.build_type }}
+          key: ${{ matrix.config.os }}-${{ matrix.build_type }}
           max-size: 500M
 
       - name: CPM Cache
@@ -186,9 +160,9 @@ jobs:
         uses: actions/cache@v2
         with:
           path: $GITHUB_WORKSPACE/.cpmcache
-          key: ${{ matrix.os }}-cpm-${{ hashFiles('**/') }}
+          key: ${{ matrix.config.os }}-cpm-${{ hashFiles('**/') }}
           restore-keys: |
-            ${{ matrix.os }}-cpm-
+            ${{ matrix.config.os }}-cpm-
 
       - name: Add clang path to $PATH env on Windows
         shell: bash
@@ -408,123 +382,3 @@ jobs:
           asset_path: ./${{ matrix.config.name }}.7z
           asset_name: ${{ matrix.config.name }}.7z.zip
           asset_content_type: application/zip
-
-  clang-format:
-    name: clang-format
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: true
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Install dependencies on ubuntu
-        run: |
-          sudo apt-get update --fix-missing
-          sudo apt-get install ninja-build
-          sudo apt-get install clang-format
-          sudo apt-get install libgles2-mesa-dev
-          ninja --version
-          cmake --version
-          gcc --version
-          clang --version
-          clang-format --version
-
-      - name: Configure
-        shell: bash
-        run: |
-          export CC=clang
-          export CXX=clang++
-          cmake \
-            -S MyApp \
-            -B MyApp/build \
-            -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
-            -DMYAPP_CI=ON \
-            -DMYAPP_CLANG_FORMAT_CHECK=ON \
-            -G "Ninja"
-
-      - name: Check
-        shell: bash
-        run: | 
-          export CC=clang
-          export CXX=clang++
-          cmake --build MyApp/build --target myapp_clang_format_check
-
-  clang-tidy:
-    name: clang-tidy
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: true
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Install dependencies on ubuntu
-        run: |
-          sudo apt-get update --fix-missing
-          sudo apt-get install ninja-build
-          sudo apt-get install clang-tidy
-          sudo apt-get install libgles2-mesa-dev
-          ninja --version
-          cmake --version
-          gcc --version
-          clang --version
-          clang-tidy --version
-
-      - name: Configure
-        shell: bash
-        run: |
-          export CC=clang
-          export CXX=clang++
-          cmake \
-            -S MyApp \
-            -B MyApp/build \
-            -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
-            -DMYAPP_CI=ON \
-            -DMYAPP_CLANG_TIDY_CHECK=ON \
-            -G "Ninja"
-
-      - name: Check
-        shell: bash
-        run: | 
-          export CC=clang
-          export CXX=clang++
-          cmake --build MyApp/build --target myapp_clang_tidy_check
-
-  cppcheck:
-    name: cppcheck
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: true
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Install dependencies on ubuntu
-        run: |
-          sudo apt-get update --fix-missing
-          sudo apt-get install ninja-build
-          sudo apt-get install cppcheck
-          sudo apt-get install libgles2-mesa-dev
-          ninja --version
-          cmake --version
-          gcc --version
-          clang --version
-          cppcheck --version
-
-      - name: Configure
-        shell: bash
-        run: |
-          export CC=clang
-          export CXX=clang++
-          cmake \
-            -S MyApp \
-            -B MyApp/build \
-            -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
-            -DMYAPP_CI=ON \
-            -DMYAPP_CPPCHECK=ON \
-            -G "Ninja"
-
-      - name: Check
-        shell: bash
-        run: | 
-          export CC=clang
-          export CXX=clang++
-          cmake --build MyApp/build --target myapp_cppcheck

--- a/.github/workflows/MyLib.yml
+++ b/.github/workflows/MyLib.yml
@@ -3,7 +3,11 @@ name: MyLib
 on:
   pull_request:
   release:
-  
+
+concurrency:
+  group: mylib-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: ${{ matrix.config.name }}
@@ -62,7 +66,7 @@ jobs:
             clang_format: "OFF",
           }
         - {
-            name: "ubuntu-gcc-asan",
+            name: "ubuntu-gcc-ubalsan",
             os: ubuntu-latest,
             build_type: "Debug",
             cc: "gcc",
@@ -70,24 +74,9 @@ jobs:
             generators: "Ninja",
             ccache: "ON",
             asan: "ON",
-            lsan: "OFF",
-            tsan: "OFF",
-            ubsan: "OFF",
-            code_coverage: "OFF",
-            clang_format: "OFF",
-          }
-        - {
-            name: "ubuntu-gcc-lsan",
-            os: ubuntu-latest,
-            build_type: "Debug",
-            cc: "gcc",
-            cxx: "g++",
-            generators: "Ninja",
-            ccache: "ON",
-            asan: "OFF",
             lsan: "ON",
             tsan: "OFF",
-            ubsan: "OFF",
+            ubsan: "ON",
             code_coverage: "OFF",
             clang_format: "OFF",
           }
@@ -103,21 +92,6 @@ jobs:
             lsan: "OFF",
             tsan: "ON",
             ubsan: "OFF",
-            code_coverage: "OFF",
-            clang_format: "OFF",
-          }
-        - {
-            name: "ubuntu-gcc-ubsan",
-            os: ubuntu-latest,
-            build_type: "Debug",
-            cc: "gcc",
-            cxx: "g++",
-            generators: "Ninja",
-            ccache: "ON",
-            asan: "OFF",
-            lsan: "OFF",
-            tsan: "OFF",
-            ubsan: "ON",
             code_coverage: "OFF",
             clang_format: "OFF",
           }
@@ -167,7 +141,7 @@ jobs:
         if: startsWith(matrix.config.ccache, 'ON')
         uses: hendrikmuhs/ccache-action@v1
         with:
-          key: ${{ matrix.os }}-${{ matrix.build_type }}
+          key: ${{ matrix.config.os }}-${{ matrix.build_type }}
           max-size: 500M
 
       - name: CPM Cache
@@ -175,9 +149,9 @@ jobs:
         uses: actions/cache@v2
         with:
           path: $GITHUB_WORKSPACE/.cpmcache
-          key: ${{ matrix.os }}-cpm-${{ hashFiles('**/') }}
+          key: ${{ matrix.config.os }}-cpm-${{ hashFiles('**/') }}
           restore-keys: |
-            ${{ matrix.os }}-cpm-
+            ${{ matrix.config.os }}-cpm-
 
       - name: Add clang path to $PATH env on Windows
         shell: bash
@@ -351,123 +325,3 @@ jobs:
           asset_path: ./${{ matrix.config.name }}.7z
           asset_name: ${{ matrix.config.name }}.7z.zip
           asset_content_type: application/zip
-
-  clang-format:
-    name: clang-format
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: true
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Install dependencies on ubuntu
-        run: |
-          sudo apt-get update --fix-missing
-          sudo apt-get install ninja-build
-          sudo apt-get install clang-format
-          sudo apt-get install libgles2-mesa-dev
-          ninja --version
-          cmake --version
-          gcc --version
-          clang --version
-          clang-format --version
-
-      - name: Configure
-        shell: bash
-        run: |
-          export CC=clang
-          export CXX=clang++
-          cmake \
-            -S MyLib \
-            -B MyLib/build \
-            -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
-            -DMYLIB_CI=ON \
-            -DMYLIB_CLANG_FORMAT_CHECK=ON \
-            -G "Ninja"
-
-      - name: Check
-        shell: bash
-        run: | 
-          export CC=clang
-          export CXX=clang++
-          cmake --build MyLib/build --target mylib_clang_format_check
-
-  clang-tidy:
-    name: clang-tidy
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: true
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Install dependencies on ubuntu
-        run: |
-          sudo apt-get update --fix-missing
-          sudo apt-get install ninja-build
-          sudo apt-get install clang-tidy
-          sudo apt-get install libgles2-mesa-dev
-          ninja --version
-          cmake --version
-          gcc --version
-          clang --version
-          clang-tidy --version
-
-      - name: Configure
-        shell: bash
-        run: |
-          export CC=clang
-          export CXX=clang++
-          cmake \
-            -S MyLib \
-            -B MyLib/build \
-            -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
-            -DMYLIB_CI=ON \
-            -DMYLIB_CLANG_TIDY_CHECK=ON \
-            -G "Ninja"
-
-      - name: Check
-        shell: bash
-        run: | 
-          export CC=clang
-          export CXX=clang++
-          cmake --build MyLib/build --target mylib_clang_tidy_check
-
-  cppcheck:
-    name: cppcheck
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: true
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Install dependencies on ubuntu
-        run: |
-          sudo apt-get update --fix-missing
-          sudo apt-get install ninja-build
-          sudo apt-get install cppcheck
-          sudo apt-get install libgles2-mesa-dev
-          ninja --version
-          cmake --version
-          gcc --version
-          clang --version
-          cppcheck --version
-
-      - name: Configure
-        shell: bash
-        run: |
-          export CC=clang
-          export CXX=clang++
-          cmake \
-            -S MyLib \
-            -B MyLib/build \
-            -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
-            -DMYLIB_CI=ON \
-            -DMYLIB_CPPCHECK=ON \
-            -G "Ninja"
-
-      - name: Check
-        shell: bash
-        run: | 
-          export CC=clang
-          export CXX=clang++
-          cmake --build MyLib/build --target mylib_cppcheck


### PR DESCRIPTION
- Adds concurrency groups to each workflow, that will cancel previous workflows on the same branch
- Moves linting (clang-format, clang-tidy, cppcheck) to a separate workflow that runs when pushing
- Adds a matrix for linting to make the YML smaller
- Consolidates all lints to the same cmake configuration run, reducing time spent grabbing redundant OS and cmake dependencies
- Consolidates ASAN, LSAN, and UBSAN in to UBALSAN, removing 2 jobs per project (that's 6 jobs removed atm)
- Fixes CPM Cache key to be the actual runner OS