### PR TITLE
CommonLib: Add input abstraction

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -19,7 +19,10 @@ Checks: '
     -readability-named-parameter,
     -cppcoreguidelines-avoid-magic-numbers,
     -modernize-use-trailing-return-type,
-    -cppcoreguidelines-pro-type-vararg, # Used extensively by C libraries
+    -cppcoreguidelines-pro-type-vararg,
+    -cppcoreguidelines-owning-memory,
+    -cppcoreguidelines-no-malloc,
+    -cppcoreguidelines-pro-type-union-access,
 '
 
 WarningsAsErrors: '*'

--- a/CommonLib/src/CMakeLists.txt
+++ b/CommonLib/src/CMakeLists.txt
@@ -4,6 +4,7 @@ include(FetchASIO)
 include(FetchGLM)
 include(FetchFMT)
 include(FetchSPDLOG)
+include(FetchMagicEnum)
 
 add_library(commonlib
     "CommonLib/Window/Window.hpp"
@@ -11,12 +12,17 @@ add_library(commonlib
     "CommonLib/Window/WindowSDL.cpp"
     "CommonLib/Window/WindowNone.hpp"
     "CommonLib/Window/WindowNone.cpp"
+
+    "CommonLib/Input/Events.hpp"
+    "CommonLib/Input/Keys.hpp"
+    "CommonLib/Input/Keys.cpp"
+    "CommonLib/Input/KeysSDL.hpp"
 )
 add_library(commonlib::commonlib ALIAS commonlib)
 
 target_include_directories(commonlib PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
 
-target_link_libraries(commonlib PUBLIC fmt::fmt spdlog::spdlog)
+target_link_libraries(commonlib PUBLIC fmt::fmt spdlog::spdlog magic_enum::magic_enum)
 
 if(${CMAKE_SYSTEM_NAME} MATCHES "Emscripten")
     target_link_options(commonlib PUBLIC "-sUSE_SDL=2" "-sUSE_FREETYPE=1")

--- a/CommonLib/src/CommonLib/Input/Events.hpp
+++ b/CommonLib/src/CommonLib/Input/Events.hpp
@@ -1,0 +1,144 @@
+#pragma once
+
+//SELF
+#include "Keys.hpp"
+
+//LIBS
+
+//STD
+#include <variant>
+#include <memory>
+
+namespace meh::common
+{
+
+template <class... Ts>
+struct overload : Ts...
+{
+    using Ts::operator()...;
+};
+template <class... Ts>
+overload(Ts...) -> overload<Ts...>;
+
+struct EventNone
+{};
+
+struct EventQuit
+{};
+struct EventClose
+{};
+
+struct EventKey
+{
+    Key key{};
+    bool down = false;
+    int scancode = 0;
+};
+
+struct EventMouseMove
+{
+    int x = 0;
+    int y = 0;
+    int xrel = 0;
+    int yrel = 0;
+};
+
+struct EventMouseButton
+{
+    Button button{};
+    bool down = false;
+    int x = 0;
+    int y = 0;
+};
+
+struct EventMouseWheel
+{
+    int horizontal = 0;
+    int vertical = 0;
+};
+
+struct EventFocus
+{
+    bool focused = false;
+};
+
+struct EventVisibility
+{
+    enum class Visibility
+    {
+        Hidden,
+        Shown,
+        Exposed,
+        Minimized,
+        Maximized,
+        Restored,
+    };
+
+    Visibility visibility{};
+};
+
+struct EventCharacter
+{
+    unsigned int character = 0;
+};
+
+struct EventMouseEnter
+{
+    bool entered = false;
+};
+
+struct EventDeviceChange
+{
+};
+
+/* Inherit from this event */
+struct EventCustom
+{
+    EventCustom(std::int32_t t)
+        : type(t)
+    {
+    }
+    virtual ~EventCustom() noexcept = default;
+
+    [[nodiscard]] std::int32_t getType() const { return type; }
+
+    template <typename T>
+    [[nodiscard]] bool is() const
+    {
+        static_assert(std::is_base_of_v<EventCustom, T>, "This type is not derived from meh::common::EventCustom");
+        return T::type_v == type;
+    }
+
+    template <typename T>
+    [[nodiscard]] T* as()
+    {
+        static_assert(std::is_base_of_v<EventCustom, T>, "This type is not derived from meh::common::EventCustom");
+        return T::type_v == type ? static_cast<T*>(this) : nullptr;
+    }
+
+    template <typename T>
+    [[nodiscard]] const T* as() const
+    {
+        static_assert(std::is_base_of_v<EventCustom, T>, "This type is not derived from meh::common::EventCustom");
+        return T::type_v == type ? static_cast<const T*>(this) : nullptr;
+    }
+
+private:
+    std::int32_t type = 0;
+};
+
+using Event = std::variant<
+    EventNone,
+    EventQuit,
+    EventClose,
+    EventKey,
+    EventMouseMove,
+    EventMouseButton,
+    EventMouseWheel,
+    EventFocus,
+    EventVisibility,
+    EventCharacter,
+    EventMouseEnter,
+    EventDeviceChange,
+    std::unique_ptr<EventCustom>>;
+} // namespace meh::common

--- a/CommonLib/src/CommonLib/Input/Keys.cpp
+++ b/CommonLib/src/CommonLib/Input/Keys.cpp
@@ -1,0 +1,34 @@
+#include "CommonLib/Input/Keys.hpp"
+
+//SELF
+
+//LIBS
+#define MAGIC_ENUM_RANGE_MIN (-512) // NOLINT(cppcoreguidelines-macro-usage)
+#define MAGIC_ENUM_RANGE_MAX (512)  // NOLINT(cppcoreguidelines-macro-usage)
+#include <magic_enum.hpp>
+
+//STD
+
+using namespace meh::common;
+
+Key meh::common::keyFromString(const std::string& str)
+{
+    return magic_enum::enum_cast<Key>(str).value_or(Key::Unknown);
+}
+
+const char* meh::common::keyToString(Key key)
+{
+    // magic enum guarantees this is a null terminated string
+    return magic_enum::enum_name(key).data();
+}
+
+Button meh::common::buttonFromString(const std::string& str)
+{
+    return magic_enum::enum_cast<Button>(str).value_or(Button::Unknown);
+}
+
+const char* meh::common::buttonToString(Button button)
+{
+    // magic enum guarantees this is a null terminated string
+    return magic_enum::enum_name(button).data();
+}

--- a/CommonLib/src/CommonLib/Input/Keys.hpp
+++ b/CommonLib/src/CommonLib/Input/Keys.hpp
@@ -1,0 +1,151 @@
+#pragma once
+
+//SELF
+
+//LIBS
+
+//STD
+#include <string>
+
+namespace meh::common
+{
+
+enum class Key
+{
+    Unknown = -1,
+
+    A,
+    B,
+    C,
+    D,
+    E,
+    F,
+    G,
+    H,
+    I,
+    J,
+    K,
+    L,
+    M,
+    N,
+    O,
+    P,
+    Q,
+    R,
+    S,
+    T,
+    U,
+    V,
+    W,
+    X,
+    Y,
+    Z,
+
+    Num0,
+    Num1,
+    Num2,
+    Num3,
+    Num4,
+    Num5,
+    Num6,
+    Num7,
+    Num8,
+    Num9,
+
+    Escape,
+    Tab,
+    Capslock,
+    Shift,
+    Control,
+    Alt,
+    Command,
+    Function,
+    Menu,
+    Enter,
+    Backspace,
+    Comma,
+    Period,
+    Slash,
+    Backslash,
+    Semicolon,
+    Quote,
+    Hash,
+    LeftBracket,
+    RightBracket,
+    Dash,
+    Space,
+
+    PageUp,
+    PageDown,
+    Home,
+    End,
+    Delete,
+    Insert,
+
+    Minus,
+    Plus,
+    Divide,
+    Multiply,
+
+    Numpad0,
+    Numpad1,
+    Numpad2,
+    Numpad3,
+    Numpad4,
+    Numpad5,
+    Numpad6,
+    Numpad7,
+    Numpad8,
+    Numpad9,
+
+    Up,
+    Down,
+    Left,
+    Right,
+
+    F1,
+    F2,
+    F3,
+    F4,
+    F5,
+    F6,
+    F7,
+    F8,
+    F9,
+    F10,
+    F11,
+    F12,
+
+    Pause,
+    PrintScreen,
+
+    KeyCount,
+
+    Windows = Command,
+    Super = Command,
+    Return = Enter,
+    Fullstop = Period,
+    Hyphen = Dash,
+    Add = Plus,
+    Forwardslash = Slash,
+};
+
+Key keyFromString(const std::string& str);
+const char* keyToString(Key key);
+
+enum class Button
+{
+    Unknown = -1,
+    Left,
+    Right,
+    Middle,
+    Button4,
+    Button5,
+
+    KeyCount,
+};
+
+Button buttonFromString(const std::string& str);
+const char* buttonToString(Button button);
+
+} // namespace meh::common

--- a/CommonLib/src/CommonLib/Input/KeysSDL.hpp
+++ b/CommonLib/src/CommonLib/Input/KeysSDL.hpp
@@ -1,0 +1,617 @@
+#pragma once
+
+//SELF
+#include "CommonLib/Input/Keys.hpp"
+
+//LIBS
+#include <cstring> //memcpy for SDL
+#include <SDL.h>
+#include <spdlog/spdlog.h>
+
+namespace meh::common
+{
+
+Key SDLKeyConversion(SDL_Keycode sdl_key)
+{
+    if (sdl_key == SDLK_UNKNOWN)
+        return Key::Unknown;
+
+    if (sdl_key == SDLK_RETURN)
+        return Key::Return;
+
+    if (sdl_key == SDLK_ESCAPE)
+        return Key::Escape;
+
+    if (sdl_key == SDLK_BACKSPACE)
+        return Key::Backspace;
+
+    if (sdl_key == SDLK_TAB)
+        return Key::Tab;
+
+    if (sdl_key == SDLK_SPACE)
+        return Key::Space;
+
+    if (sdl_key == SDLK_EXCLAIM)
+        return Key::Unknown;
+
+    if (sdl_key == SDLK_QUOTEDBL)
+        return Key::Quote;
+
+    if (sdl_key == SDLK_HASH)
+        return Key::Hash;
+
+    if (sdl_key == SDLK_PERCENT)
+        return Key::Unknown;
+
+    if (sdl_key == SDLK_DOLLAR)
+        return Key::Unknown;
+
+    if (sdl_key == SDLK_AMPERSAND)
+        return Key::Unknown;
+
+    if (sdl_key == SDLK_QUOTE)
+        return Key::Unknown;
+
+    if (sdl_key == SDLK_LEFTPAREN)
+        return Key::LeftBracket;
+
+    if (sdl_key == SDLK_RIGHTPAREN)
+        return Key::RightBracket;
+
+    if (sdl_key == SDLK_ASTERISK)
+        return Key::Multiply;
+
+    if (sdl_key == SDLK_PLUS)
+        return Key::Plus;
+
+    if (sdl_key == SDLK_COMMA)
+        return Key::Comma;
+
+    if (sdl_key == SDLK_MINUS)
+        return Key::Minus;
+
+    if (sdl_key == SDLK_PERIOD)
+        return Key::Period;
+
+    if (sdl_key == SDLK_SLASH)
+        return Key::Slash;
+
+    if (sdl_key == SDLK_0)
+        return Key::Num0;
+
+    if (sdl_key == SDLK_1)
+        return Key::Num1;
+
+    if (sdl_key == SDLK_2)
+        return Key::Num2;
+
+    if (sdl_key == SDLK_3)
+        return Key::Num3;
+
+    if (sdl_key == SDLK_4)
+        return Key::Num4;
+
+    if (sdl_key == SDLK_5)
+        return Key::Num5;
+
+    if (sdl_key == SDLK_6)
+        return Key::Num6;
+
+    if (sdl_key == SDLK_7)
+        return Key::Num7;
+
+    if (sdl_key == SDLK_8)
+        return Key::Num8;
+
+    if (sdl_key == SDLK_9)
+        return Key::Num9;
+
+    if (sdl_key == SDLK_COLON)
+        return Key::Unknown;
+
+    if (sdl_key == SDLK_SEMICOLON)
+        return Key::Semicolon;
+
+    if (sdl_key == SDLK_LESS)
+        return Key::Unknown;
+
+    if (sdl_key == SDLK_EQUALS)
+        return Key::Unknown;
+
+    if (sdl_key == SDLK_GREATER)
+        return Key::Unknown;
+
+    if (sdl_key == SDLK_QUESTION)
+        return Key::Unknown;
+
+    if (sdl_key == SDLK_AT)
+        return Key::Unknown;
+
+    if (sdl_key == SDLK_LEFTBRACKET)
+        return Key::Unknown;
+
+    if (sdl_key == SDLK_BACKSLASH)
+        return Key::Backslash;
+
+    if (sdl_key == SDLK_RIGHTBRACKET)
+        return Key::Unknown;
+
+    if (sdl_key == SDLK_CARET)
+        return Key::Unknown;
+
+    if (sdl_key == SDLK_UNDERSCORE)
+        return Key::Unknown;
+
+    if (sdl_key == SDLK_BACKQUOTE)
+        return Key::Unknown;
+
+    if (sdl_key == SDLK_a)
+        return Key::A;
+
+    if (sdl_key == SDLK_b)
+        return Key::B;
+
+    if (sdl_key == SDLK_c)
+        return Key::C;
+
+    if (sdl_key == SDLK_d)
+        return Key::D;
+
+    if (sdl_key == SDLK_e)
+        return Key::E;
+
+    if (sdl_key == SDLK_f)
+        return Key::F;
+
+    if (sdl_key == SDLK_g)
+        return Key::G;
+
+    if (sdl_key == SDLK_h)
+        return Key::H;
+
+    if (sdl_key == SDLK_i)
+        return Key::I;
+
+    if (sdl_key == SDLK_j)
+        return Key::J;
+
+    if (sdl_key == SDLK_k)
+        return Key::K;
+
+    if (sdl_key == SDLK_l)
+        return Key::L;
+
+    if (sdl_key == SDLK_m)
+        return Key::M;
+
+    if (sdl_key == SDLK_n)
+        return Key::N;
+
+    if (sdl_key == SDLK_o)
+        return Key::O;
+
+    if (sdl_key == SDLK_p)
+        return Key::P;
+
+    if (sdl_key == SDLK_q)
+        return Key::Q;
+
+    if (sdl_key == SDLK_r)
+        return Key::R;
+
+    if (sdl_key == SDLK_s)
+        return Key::S;
+
+    if (sdl_key == SDLK_t)
+        return Key::T;
+
+    if (sdl_key == SDLK_u)
+        return Key::U;
+
+    if (sdl_key == SDLK_v)
+        return Key::V;
+
+    if (sdl_key == SDLK_w)
+        return Key::W;
+
+    if (sdl_key == SDLK_x)
+        return Key::X;
+
+    if (sdl_key == SDLK_y)
+        return Key::Y;
+
+    if (sdl_key == SDLK_z)
+        return Key::Z;
+
+    if (sdl_key == SDLK_CAPSLOCK)
+        return Key::Capslock;
+
+    if (sdl_key == SDLK_F1)
+        return Key::F1;
+
+    if (sdl_key == SDLK_F2)
+        return Key::F2;
+
+    if (sdl_key == SDLK_F3)
+        return Key::F3;
+
+    if (sdl_key == SDLK_F4)
+        return Key::F4;
+
+    if (sdl_key == SDLK_F5)
+        return Key::F5;
+
+    if (sdl_key == SDLK_F6)
+        return Key::F6;
+
+    if (sdl_key == SDLK_F7)
+        return Key::F7;
+
+    if (sdl_key == SDLK_F8)
+        return Key::F8;
+
+    if (sdl_key == SDLK_F9)
+        return Key::F9;
+
+    if (sdl_key == SDLK_F10)
+        return Key::F10;
+
+    if (sdl_key == SDLK_F11)
+        return Key::F11;
+
+    if (sdl_key == SDLK_F12)
+        return Key::F12;
+
+    if (sdl_key == SDLK_F13)
+        return Key::Unknown;
+
+    if (sdl_key == SDLK_F14)
+        return Key::Unknown;
+
+    if (sdl_key == SDLK_F15)
+        return Key::Unknown;
+
+    if (sdl_key == SDLK_F16)
+        return Key::Unknown;
+
+    if (sdl_key == SDLK_F17)
+        return Key::Unknown;
+
+    if (sdl_key == SDLK_F18)
+        return Key::Unknown;
+
+    if (sdl_key == SDLK_F19)
+        return Key::Unknown;
+
+    if (sdl_key == SDLK_F20)
+        return Key::Unknown;
+
+    if (sdl_key == SDLK_F21)
+        return Key::Unknown;
+
+    if (sdl_key == SDLK_F22)
+        return Key::Unknown;
+
+    if (sdl_key == SDLK_F23)
+        return Key::Unknown;
+
+    if (sdl_key == SDLK_F24)
+        return Key::Unknown;
+
+    if (sdl_key == SDLK_PRINTSCREEN)
+        return Key::PrintScreen;
+    if (sdl_key == SDLK_SCROLLLOCK)
+        return Key::Unknown;
+    if (sdl_key == SDLK_PAUSE)
+        return Key::Pause;
+    if (sdl_key == SDLK_INSERT)
+        return Key::Insert;
+    if (sdl_key == SDLK_HOME)
+        return Key::Home;
+    if (sdl_key == SDLK_PAGEUP)
+        return Key::PageUp;
+    if (sdl_key == SDLK_DELETE)
+        return Key::Delete;
+    if (sdl_key == SDLK_END)
+        return Key::End;
+    if (sdl_key == SDLK_PAGEDOWN)
+        return Key::PageDown;
+    if (sdl_key == SDLK_RIGHT)
+        return Key::Right;
+    if (sdl_key == SDLK_LEFT)
+        return Key::Left;
+    if (sdl_key == SDLK_DOWN)
+        return Key::Down;
+    if (sdl_key == SDLK_UP)
+        return Key::Up;
+    if (sdl_key == SDLK_NUMLOCKCLEAR)
+        return Key::Unknown;
+    if (sdl_key == SDLK_KP_DIVIDE)
+        return Key::Divide;
+    if (sdl_key == SDLK_KP_MULTIPLY)
+        return Key::Multiply;
+    if (sdl_key == SDLK_KP_MINUS)
+        return Key::Minus;
+    if (sdl_key == SDLK_KP_PLUS)
+        return Key::Plus;
+    if (sdl_key == SDLK_KP_ENTER)
+        return Key::Enter;
+    if (sdl_key == SDLK_KP_0)
+        return Key::Numpad0;
+    if (sdl_key == SDLK_KP_1)
+        return Key::Numpad1;
+    if (sdl_key == SDLK_KP_2)
+        return Key::Numpad2;
+    if (sdl_key == SDLK_KP_3)
+        return Key::Numpad3;
+    if (sdl_key == SDLK_KP_4)
+        return Key::Numpad4;
+    if (sdl_key == SDLK_KP_5)
+        return Key::Numpad5;
+    if (sdl_key == SDLK_KP_6)
+        return Key::Numpad6;
+    if (sdl_key == SDLK_KP_7)
+        return Key::Numpad7;
+    if (sdl_key == SDLK_KP_8)
+        return Key::Numpad8;
+    if (sdl_key == SDLK_KP_9)
+        return Key::Numpad9;
+    if (sdl_key == SDLK_KP_PERIOD)
+        return Key::Period;
+    if (sdl_key == SDLK_APPLICATION)
+        return Key::Unknown;
+    if (sdl_key == SDLK_POWER)
+        return Key::Unknown;
+    if (sdl_key == SDLK_KP_EQUALS)
+        return Key::Unknown;
+    if (sdl_key == SDLK_EXECUTE)
+        return Key::Unknown;
+    if (sdl_key == SDLK_HELP)
+        return Key::Unknown;
+    if (sdl_key == SDLK_MENU)
+        return Key::Unknown;
+    if (sdl_key == SDLK_SELECT)
+        return Key::Unknown;
+    if (sdl_key == SDLK_STOP)
+        return Key::Unknown;
+    if (sdl_key == SDLK_AGAIN)
+        return Key::Unknown;
+    if (sdl_key == SDLK_UNDO)
+        return Key::Unknown;
+    if (sdl_key == SDLK_CUT)
+        return Key::Unknown;
+    if (sdl_key == SDLK_COPY)
+        return Key::Unknown;
+    if (sdl_key == SDLK_PASTE)
+        return Key::Unknown;
+    if (sdl_key == SDLK_FIND)
+        return Key::Unknown;
+    if (sdl_key == SDLK_MUTE)
+        return Key::Unknown;
+    if (sdl_key == SDLK_VOLUMEUP)
+        return Key::Unknown;
+    if (sdl_key == SDLK_VOLUMEDOWN)
+        return Key::Unknown;
+    if (sdl_key == SDLK_KP_COMMA)
+        return Key::Comma;
+    if (sdl_key == SDLK_KP_EQUALSAS400)
+        return Key::Unknown;
+    if (sdl_key == SDLK_ALTERASE)
+        return Key::Unknown;
+    if (sdl_key == SDLK_SYSREQ)
+        return Key::Unknown;
+    if (sdl_key == SDLK_CANCEL)
+        return Key::Unknown;
+    if (sdl_key == SDLK_CLEAR)
+        return Key::Unknown;
+    if (sdl_key == SDLK_PRIOR)
+        return Key::Unknown;
+    if (sdl_key == SDLK_RETURN2)
+        return Key::Unknown;
+    if (sdl_key == SDLK_SEPARATOR)
+        return Key::Unknown;
+    if (sdl_key == SDLK_OUT)
+        return Key::Unknown;
+    if (sdl_key == SDLK_OPER)
+        return Key::Unknown;
+    if (sdl_key == SDLK_CLEARAGAIN)
+        return Key::Unknown;
+    if (sdl_key == SDLK_CRSEL)
+        return Key::Unknown;
+    if (sdl_key == SDLK_EXSEL)
+        return Key::Unknown;
+    if (sdl_key == SDLK_KP_00)
+        return Key::Unknown;
+    if (sdl_key == SDLK_KP_000)
+        return Key::Unknown;
+    if (sdl_key == SDLK_THOUSANDSSEPARATOR)
+        return Key::Unknown;
+    if (sdl_key == SDLK_DECIMALSEPARATOR)
+        return Key::Unknown;
+    if (sdl_key == SDLK_CURRENCYUNIT)
+        return Key::Unknown;
+    if (sdl_key == SDLK_CURRENCYSUBUNIT)
+        return Key::Unknown;
+    if (sdl_key == SDLK_KP_LEFTPAREN)
+        return Key::LeftBracket;
+    if (sdl_key == SDLK_KP_RIGHTPAREN)
+        return Key::RightBracket;
+    if (sdl_key == SDLK_KP_LEFTBRACE)
+        return Key::Unknown;
+    if (sdl_key == SDLK_KP_RIGHTBRACE)
+        return Key::Unknown;
+    if (sdl_key == SDLK_KP_TAB)
+        return Key::Tab;
+    if (sdl_key == SDLK_KP_BACKSPACE)
+        return Key::Backspace;
+    if (sdl_key == SDLK_KP_A)
+        return Key::A;
+    if (sdl_key == SDLK_KP_B)
+        return Key::B;
+    if (sdl_key == SDLK_KP_C)
+        return Key::C;
+    if (sdl_key == SDLK_KP_D)
+        return Key::D;
+    if (sdl_key == SDLK_KP_E)
+        return Key::E;
+    if (sdl_key == SDLK_KP_F)
+        return Key::F;
+    if (sdl_key == SDLK_KP_XOR)
+        return Key::Unknown;
+    if (sdl_key == SDLK_KP_POWER)
+        return Key::Unknown;
+    if (sdl_key == SDLK_KP_PERCENT)
+        return Key::Unknown;
+    if (sdl_key == SDLK_KP_LESS)
+        return Key::Unknown;
+    if (sdl_key == SDLK_KP_GREATER)
+        return Key::Unknown;
+    if (sdl_key == SDLK_KP_AMPERSAND)
+        return Key::Unknown;
+    if (sdl_key == SDLK_KP_DBLAMPERSAND)
+        return Key::Unknown;
+    if (sdl_key == SDLK_KP_VERTICALBAR)
+        return Key::Unknown;
+    if (sdl_key == SDLK_KP_DBLVERTICALBAR)
+        return Key::Unknown;
+    if (sdl_key == SDLK_KP_COLON)
+        return Key::Unknown;
+    if (sdl_key == SDLK_KP_HASH)
+        return Key::Unknown;
+    if (sdl_key == SDLK_KP_SPACE)
+        return Key::Space;
+    if (sdl_key == SDLK_KP_AT)
+        return Key::Unknown;
+    if (sdl_key == SDLK_KP_EXCLAM)
+        return Key::Unknown;
+    if (sdl_key == SDLK_KP_MEMSTORE)
+        return Key::Unknown;
+    if (sdl_key == SDLK_KP_MEMRECALL)
+        return Key::Unknown;
+    if (sdl_key == SDLK_KP_MEMCLEAR)
+        return Key::Unknown;
+    if (sdl_key == SDLK_KP_MEMADD)
+        return Key::Unknown;
+    if (sdl_key == SDLK_KP_MEMSUBTRACT)
+        return Key::Unknown;
+    if (sdl_key == SDLK_KP_MEMMULTIPLY)
+        return Key::Unknown;
+    if (sdl_key == SDLK_KP_MEMDIVIDE)
+        return Key::Unknown;
+    if (sdl_key == SDLK_KP_PLUSMINUS)
+        return Key::Unknown;
+    if (sdl_key == SDLK_KP_CLEAR)
+        return Key::Unknown;
+    if (sdl_key == SDLK_KP_CLEARENTRY)
+        return Key::Unknown;
+    if (sdl_key == SDLK_KP_BINARY)
+        return Key::Unknown;
+    if (sdl_key == SDLK_KP_OCTAL)
+        return Key::Unknown;
+    if (sdl_key == SDLK_KP_DECIMAL)
+        return Key::Unknown;
+    if (sdl_key == SDLK_KP_HEXADECIMAL)
+        return Key::Unknown;
+    if (sdl_key == SDLK_LCTRL)
+        return Key::Control;
+    if (sdl_key == SDLK_LSHIFT)
+        return Key::Shift;
+    if (sdl_key == SDLK_LALT)
+        return Key::Alt;
+    if (sdl_key == SDLK_LGUI)
+        return Key::Unknown;
+    if (sdl_key == SDLK_RCTRL)
+        return Key::Control;
+    if (sdl_key == SDLK_RSHIFT)
+        return Key::Shift;
+    if (sdl_key == SDLK_RALT)
+        return Key::Alt;
+    if (sdl_key == SDLK_RGUI)
+        return Key::Unknown;
+    if (sdl_key == SDLK_MODE)
+        return Key::Unknown;
+    if (sdl_key == SDLK_AUDIONEXT)
+        return Key::Unknown;
+    if (sdl_key == SDLK_AUDIOPREV)
+        return Key::Unknown;
+    if (sdl_key == SDLK_AUDIOSTOP)
+        return Key::Unknown;
+    if (sdl_key == SDLK_AUDIOPLAY)
+        return Key::Unknown;
+    if (sdl_key == SDLK_AUDIOMUTE)
+        return Key::Unknown;
+    if (sdl_key == SDLK_MEDIASELECT)
+        return Key::Unknown;
+    if (sdl_key == SDLK_WWW)
+        return Key::Unknown;
+    if (sdl_key == SDLK_MAIL)
+        return Key::Unknown;
+    if (sdl_key == SDLK_CALCULATOR)
+        return Key::Unknown;
+    if (sdl_key == SDLK_COMPUTER)
+        return Key::Unknown;
+    if (sdl_key == SDLK_AC_SEARCH)
+        return Key::Unknown;
+    if (sdl_key == SDLK_AC_HOME)
+        return Key::Unknown;
+    if (sdl_key == SDLK_AC_BACK)
+        return Key::Unknown;
+    if (sdl_key == SDLK_AC_FORWARD)
+        return Key::Unknown;
+    if (sdl_key == SDLK_AC_STOP)
+        return Key::Unknown;
+    if (sdl_key == SDLK_AC_REFRESH)
+        return Key::Unknown;
+    if (sdl_key == SDLK_AC_BOOKMARKS)
+        return Key::Unknown;
+    if (sdl_key == SDLK_BRIGHTNESSDOWN)
+        return Key::Unknown;
+    if (sdl_key == SDLK_BRIGHTNESSUP)
+        return Key::Unknown;
+    if (sdl_key == SDLK_DISPLAYSWITCH)
+        return Key::Unknown;
+    if (sdl_key == SDLK_KBDILLUMTOGGLE)
+        return Key::Unknown;
+    if (sdl_key == SDLK_KBDILLUMDOWN)
+        return Key::Unknown;
+    if (sdl_key == SDLK_KBDILLUMUP)
+        return Key::Unknown;
+    if (sdl_key == SDLK_EJECT)
+        return Key::Unknown;
+    if (sdl_key == SDLK_SLEEP)
+        return Key::Unknown;
+    if (sdl_key == SDLK_APP1)
+        return Key::Unknown;
+    if (sdl_key == SDLK_APP2)
+        return Key::Unknown;
+    if (sdl_key == SDLK_APP2)
+        return Key::Unknown;
+    if (sdl_key == SDLK_AUDIOFASTFORWARD)
+        return Key::Unknown;
+
+    spdlog::error("Unknown SDL key {} when converting to actual key", sdl_key);
+    return Key::Unknown;
+}
+
+Button SDLButtonConversion(int sdl_button)
+{
+    if (sdl_button == SDL_BUTTON_LEFT)
+        return Button::Left;
+
+    if (sdl_button == SDL_BUTTON_MIDDLE)
+        return Button::Middle;
+
+    if (sdl_button == SDL_BUTTON_RIGHT)
+        return Button::Right;
+
+    if (sdl_button == SDL_BUTTON_X1)
+        return Button::Button4;
+
+    if (sdl_button == SDL_BUTTON_X2)
+        return Button::Button5;
+
+    spdlog::error("Unknown SDL button {} when converting to actual button", sdl_button);
+    return Button::Unknown;
+}
+
+} // namespace meh::common

--- a/CommonLib/src/CommonLib/Window/Window.hpp
+++ b/CommonLib/src/CommonLib/Window/Window.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 //SELF
+#include "CommonLib/Input/Events.hpp"
 
 //LIBS
 
@@ -33,7 +34,9 @@ public:
     Window& operator=(const Window&) noexcept = delete;
     virtual ~Window() noexcept = default;
 
-    //virtual bool poll(Event& e) = 0;
+    virtual bool poll(Event& event) = 0;
+    virtual void send(Event event) = 0;
+
     [[nodiscard]] virtual bool isOpen() const = 0;
     [[nodiscard]] virtual bool isVerticalSyncEnabled() const = 0;
 
@@ -51,7 +54,7 @@ public:
     [[nodiscard]] std::int32_t getType() const { return type; }
 
     template <typename T>
-    [[nodiscard]] bool is()
+    [[nodiscard]] bool is() const
     {
         static_assert(std::is_base_of_v<Window, T>, "This type is not derived from meh::common::Window");
         return T::type_v == type;

--- a/CommonLib/src/CommonLib/Window/WindowNone.cpp
+++ b/CommonLib/src/CommonLib/Window/WindowNone.cpp
@@ -23,6 +23,24 @@ unsigned int WindowNone::getHeight() const
     return settings.height;
 }
 
+bool WindowNone::poll(Event& event)
+{
+    if (sent_events.empty())
+    {
+        event = EventNone{};
+        return false;
+    }
+
+    event = std::move(sent_events.front());
+    sent_events.pop();
+    return true;
+}
+
+void WindowNone::send(Event event)
+{
+    sent_events.push(std::move(event));
+}
+
 bool WindowNone::isOpen() const
 {
     return is_open;

--- a/CommonLib/src/CommonLib/Window/WindowNone.hpp
+++ b/CommonLib/src/CommonLib/Window/WindowNone.hpp
@@ -7,6 +7,7 @@
 
 //STD
 #include <string>
+#include <queue>
 
 namespace meh::common
 {
@@ -20,7 +21,9 @@ public:
     WindowNone& operator=(WindowNone&&) noexcept = delete;
     WindowNone& operator=(const WindowNone&) noexcept = delete;
 
-    //virtual bool poll(Event& e) final;
+    virtual bool poll(Event& event) final;
+    virtual void send(Event event) final;
+
     [[nodiscard]] virtual bool isOpen() const final;
     [[nodiscard]] virtual bool isVerticalSyncEnabled() const final;
 
@@ -39,6 +42,7 @@ public:
 
 private:
     bool is_open = true;
+    std::queue<Event> sent_events;
 };
 
 } // namespace meh::common

--- a/CommonLib/src/CommonLib/Window/WindowSDL.cpp
+++ b/CommonLib/src/CommonLib/Window/WindowSDL.cpp
@@ -1,6 +1,7 @@
 #include "WindowSDL.hpp"
 
 //SELF
+#include <CommonLib/Input/KeysSDL.hpp>
 
 //LIBS
 #ifdef __EMSCRIPTEN__
@@ -14,6 +15,8 @@
     #include <cstring> //memcpy for SDL
     #include <SDL.h>
 #endif
+
+#include <spdlog/spdlog.h>
 
 //STD
 
@@ -39,6 +42,330 @@ unsigned int WindowSDL::getWidth() const
 unsigned int WindowSDL::getHeight() const
 {
     return settings.height;
+}
+
+bool WindowSDL::poll(Event& event)
+{
+    if (!sent_events.empty())
+    {
+        event = std::move(sent_events.front());
+        sent_events.pop();
+        return true;
+    }
+
+    SDL_Event sdl_event;
+    const auto found_event = SDL_PollEvent(&sdl_event) != 0;
+    event = EventNone{};
+    if (!found_event)
+        return false;
+
+    switch (sdl_event.type)
+    {
+    case SDL_QUIT:
+    {
+        spdlog::info("App is quitting");
+        event = EventQuit{};
+        break;
+    }
+    case SDL_APP_TERMINATING:
+    {
+        spdlog::info("App is terminating");
+        break;
+    }
+    case SDL_APP_LOWMEMORY:
+    {
+        spdlog::info("App is low on memory");
+        break;
+    }
+    case SDL_APP_WILLENTERBACKGROUND:
+    {
+        spdlog::info("App is entering background");
+        break;
+    }
+    case SDL_APP_DIDENTERBACKGROUND:
+    {
+        spdlog::info("App entered background");
+        break;
+    }
+    case SDL_APP_WILLENTERFOREGROUND:
+    {
+        spdlog::info("App is entering foreground");
+        break;
+    }
+    case SDL_APP_DIDENTERFOREGROUND:
+    {
+        spdlog::info("App entered foreground");
+        break;
+    }
+    case SDL_WINDOWEVENT:
+    {
+        auto& window_event = sdl_event.window;
+
+        switch (window_event.event)
+        {
+        case SDL_WINDOWEVENT_SHOWN:
+        {
+            //spdlog::info("Window {} shown", window_event.windowID);
+            event = EventVisibility{ EventVisibility::Visibility::Shown };
+            break;
+        }
+        case SDL_WINDOWEVENT_HIDDEN:
+        {
+            //spdlog::info("Window {} hidden", window_event.windowID);
+            event = EventVisibility{ EventVisibility::Visibility::Hidden };
+            break;
+        }
+        case SDL_WINDOWEVENT_EXPOSED:
+        {
+            //spdlog::info("Window {} exposed", window_event.windowID);
+            event = EventVisibility{ EventVisibility::Visibility::Exposed };
+            break;
+        }
+        case SDL_WINDOWEVENT_MOVED:
+        {
+            spdlog::info("Window {} moved to {},{}",
+                         window_event.windowID, window_event.data1, window_event.data2);
+            break;
+        }
+        case SDL_WINDOWEVENT_RESIZED:
+        {
+            spdlog::info("Window {} resized to {},{}",
+                         window_event.windowID, window_event.data1, window_event.data2);
+            break;
+        }
+        case SDL_WINDOWEVENT_SIZE_CHANGED:
+        {
+            spdlog::info("Window {} size changed to {},{}",
+                         window_event.windowID, window_event.data1, window_event.data2);
+            break;
+        }
+        case SDL_WINDOWEVENT_MINIMIZED:
+        {
+            //spdlog::info("Window {} minimized", window_event.windowID);
+            event = EventVisibility{ EventVisibility::Visibility::Minimized };
+            break;
+        }
+        case SDL_WINDOWEVENT_MAXIMIZED:
+        {
+            //spdlog::info("Window {} maximized", window_event.windowID);
+            event = EventVisibility{ EventVisibility::Visibility::Maximized };
+            break;
+        }
+        case SDL_WINDOWEVENT_RESTORED:
+        {
+            //spdlog::info("Window {} restored", window_event.windowID);
+            event = EventVisibility{ EventVisibility::Visibility::Restored };
+            break;
+        }
+        case SDL_WINDOWEVENT_ENTER:
+        {
+            //spdlog::info("Mouse entered window {}", window_event.windowID);
+            event = EventMouseEnter{ true };
+            break;
+        }
+        case SDL_WINDOWEVENT_LEAVE:
+        {
+            //spdlog::info("Mouse left window {}", window_event.windowID);
+            event = EventMouseEnter{ false };
+            break;
+        }
+        case SDL_WINDOWEVENT_FOCUS_GAINED:
+        {
+            //spdlog::info("Window {} gained keyboard focus", window_event.windowID);
+            event = EventFocus{ true };
+            break;
+        }
+        case SDL_WINDOWEVENT_FOCUS_LOST:
+        {
+            //spdlog::info("Window {} lost keyboard focus", window_event.windowID);
+            event = EventFocus{ false };
+            break;
+        }
+        case SDL_WINDOWEVENT_CLOSE:
+        {
+            //spdlog::info("Window {} closed", window_event.windowID);
+            event = EventClose();
+            break;
+        }
+        case SDL_WINDOWEVENT_TAKE_FOCUS:
+        {
+            spdlog::info("Window {} is offered a focus", window_event.windowID);
+            break;
+        }
+        case SDL_WINDOWEVENT_HIT_TEST:
+        {
+            spdlog::info("Window {} has a special hit test", window_event.windowID);
+            break;
+        }
+        default:
+        {
+            spdlog::info("Window {} received an unknown event", window_event.windowID);
+            break;
+        }
+        }
+        break;
+    }
+    case SDL_SYSWMEVENT:
+    {
+        spdlog::info("SysWMEvent");
+        break;
+    }
+    case SDL_KEYDOWN:
+    {
+        /*spdlog::info("Keydown {} {}",
+                SDL_GetScancodeName(sdl_event.key.keysym.scancode), SDL_GetKeyName(sdl_event.key.keysym.sym));*/
+        event = EventKey{ SDLKeyConversion(sdl_event.key.keysym.sym), true, static_cast<std::int32_t>(sdl_event.key.keysym.scancode) };
+        break;
+    }
+    case SDL_KEYUP:
+    {
+        /*spdlog::info("Keyup {} {}",
+                SDL_GetScancodeName(sdl_event.key.keysym.scancode), SDL_GetKeyName(sdl_event.key.keysym.sym));*/
+        event = EventKey{ SDLKeyConversion(sdl_event.key.keysym.sym), false, static_cast<std::int32_t>(sdl_event.key.keysym.scancode) };
+        break;
+    }
+    case SDL_TEXTEDITING:
+    {
+        spdlog::info("In window {}, editing text {}, with a start of {} and a length of {}",
+                     sdl_event.edit.windowID,
+                     sdl_event.edit.text,
+                     sdl_event.edit.start,
+                     sdl_event.edit.length);
+        break;
+    }
+    case SDL_TEXTINPUT:
+    {
+        spdlog::info("In window {}, inputing text {}",
+                     sdl_event.edit.windowID,
+                     sdl_event.edit.text);
+        break;
+    }
+    case SDL_KEYMAPCHANGED:
+    {
+        spdlog::info("Keymap Changed");
+        break;
+    }
+    case SDL_MOUSEMOTION:
+    {
+        /*spdlog::info("In window {}, mouse {} moved from {}, {} to {}, {}\nM1={}, M2={}, M3={}, M4={}, M5={}",
+                sdl_event.motion.windowID,
+                sdl_event.motion.which,
+                sdl_event.motion.x - sdl_event.motion.xrel,
+                sdl_event.motion.y - sdl_event.motion.yrel,
+                sdl_event.motion.x,
+                sdl_event.motion.y,
+                sdl_event.motion.state & SDL_BUTTON_LMASK,
+                sdl_event.motion.state & SDL_BUTTON_RMASK,
+                sdl_event.motion.state & SDL_BUTTON_MMASK,
+                sdl_event.motion.state & SDL_BUTTON_X1MASK,
+                sdl_event.motion.state & SDL_BUTTON_X2MASK);*/
+        event = EventMouseMove{ sdl_event.motion.x, sdl_event.motion.y, sdl_event.motion.xrel, sdl_event.motion.yrel };
+        break;
+    }
+    case SDL_MOUSEBUTTONDOWN:
+    {
+        /*spdlog::info("In window {}, mouse {} is down at {}, {}\nclicks={} button={}",
+                sdl_event.button.windowID, sdl_event.button.which, sdl_event.button.x, sdl_event.button.y,
+                sdl_event.button.clicks, sdl_event.button.button);*/
+        event = EventMouseButton{ SDLButtonConversion(sdl_event.button.button), true, sdl_event.button.x, sdl_event.button.y };
+        break;
+    }
+    case SDL_MOUSEBUTTONUP:
+    {
+        /*spdlog::info("In window {}, mouse {} is up at {}, {}\nclicks={} button={}",
+                sdl_event.button.windowID, sdl_event.button.which, sdl_event.button.x, sdl_event.button.y,
+                sdl_event.button.clicks, sdl_event.button.button);*/
+        event = EventMouseButton{ SDLButtonConversion(sdl_event.button.button), false, sdl_event.button.x, sdl_event.button.y };
+        break;
+    }
+    case SDL_MOUSEWHEEL:
+    {
+        /*spdlog::info("In window {}, mousewheel {} scrolled {},{} ({})",
+                     sdl_event.wheel.windowID,
+                     sdl_event.wheel.which,
+                     sdl_event.wheel.x,
+                     sdl_event.wheel.y,
+                     sdl_event.wheel.direction == SDL_MOUSEWHEEL_NORMAL ? "normal" : "inverted");*/
+
+        if (sdl_event.wheel.direction == SDL_MOUSEWHEEL_NORMAL)
+            event = EventMouseWheel{ sdl_event.wheel.x, sdl_event.wheel.y };
+        else
+            event = EventMouseWheel{ sdl_event.wheel.y, sdl_event.wheel.x };
+
+        break;
+    }
+    case SDL_CLIPBOARDUPDATE:
+    {
+        spdlog::info("clipboard has changed");
+        break;
+    }
+    case SDL_DROPFILE:
+    {
+        spdlog::info("File {} drop on window {}", sdl_event.drop.windowID, sdl_event.drop.file);
+        SDL_free(sdl_event.drop.file);
+        break;
+    }
+    case SDL_DROPTEXT:
+    {
+        spdlog::info("Text {} drop on window {}", sdl_event.drop.windowID, sdl_event.drop.file);
+        SDL_free(sdl_event.drop.file);
+        break;
+    }
+    case SDL_DROPBEGIN:
+    {
+        spdlog::info("File {} drop on window {} begun", sdl_event.drop.windowID, sdl_event.drop.file);
+        SDL_free(sdl_event.drop.file);
+        break;
+    }
+    case SDL_DROPCOMPLETE:
+    {
+        spdlog::info("File {} drop on window {} completed", sdl_event.drop.windowID, sdl_event.drop.file);
+        SDL_free(sdl_event.drop.file);
+        break;
+    }
+    case SDL_AUDIODEVICEADDED:
+    {
+        spdlog::info("Audio Device {} added. iscapture={}", sdl_event.adevice.which, sdl_event.adevice.iscapture);
+        break;
+    }
+    case SDL_AUDIODEVICEREMOVED:
+    {
+        spdlog::info("Audio Device {} removed. iscapture={}", sdl_event.adevice.which, sdl_event.adevice.iscapture);
+        break;
+    }
+    case SDL_RENDER_TARGETS_RESET:
+    {
+        spdlog::info("Render Target Reset");
+        break;
+    }
+    case SDL_RENDER_DEVICE_RESET:
+    {
+        spdlog::info("Render Device Reset");
+        break;
+    }
+    case SDL_USEREVENT:
+    {
+        spdlog::info("UserEvent");
+        break;
+    }
+    case SDL_LASTEVENT:
+    {
+        spdlog::info("Unreachable");
+        break;
+    }
+    default:
+    {
+        spdlog::info("sdl_event type of {}: was it a joystick/controller/finger gestures event?", sdl_event.type);
+        break;
+    }
+    }
+
+    return found_event;
+}
+
+void WindowSDL::send(Event event)
+{
+    sent_events.push(std::move(event));
 }
 
 bool WindowSDL::isOpen() const

--- a/CommonLib/src/CommonLib/Window/WindowSDL.hpp
+++ b/CommonLib/src/CommonLib/Window/WindowSDL.hpp
@@ -7,6 +7,7 @@
 
 //STD
 #include <string>
+#include <queue>
 
 struct SDL_Window;
 
@@ -23,7 +24,9 @@ public:
     WindowSDL& operator=(const WindowSDL&) noexcept = delete;
     ~WindowSDL() noexcept final;
 
-    //virtual bool poll(Event& e) final;
+    virtual bool poll(Event& event) final;
+    virtual void send(Event event) final;
+
     [[nodiscard]] virtual bool isOpen() const final;
     [[nodiscard]] virtual bool isVerticalSyncEnabled() const final;
 
@@ -45,6 +48,7 @@ public:
 private:
     bool is_open = true;
     SDL_Window* raw_window;
+    std::queue<Event> sent_events;
 };
 
 } // namespace meh::common

--- a/CommonLib/tests/commonlib.hpp
+++ b/CommonLib/tests/commonlib.hpp
@@ -6,10 +6,58 @@
 
 //STD
 
-TEST_CASE("test")
+TEST_CASE("WindowNone/isOpen & close")
 {
     meh::common::WindowNone window({});
-    REQUIRE(window.isOpen());
+    CHECK(window.isOpen());
     window.close();
-    REQUIRE(!window.isOpen());
+    CHECK(!window.isOpen());
+}
+
+TEST_CASE("WindowNone/Send & Poll")
+{
+    meh::common::WindowNone window({});
+    meh::common::Event event;
+    CHECK(std::holds_alternative<meh::common::EventNone>(event));
+    CHECK(!window.poll(event));
+    CHECK(std::holds_alternative<meh::common::EventNone>(event));
+
+    window.send(meh::common::EventQuit{});
+    auto found_event = window.poll(event);
+    CHECK(found_event);
+    CHECK(std::holds_alternative<meh::common::EventQuit>(event));
+    CHECK(!window.poll(event));
+}
+
+struct MyEvent : public meh::common::EventCustom
+{
+    MyEvent(std::string s)
+        : meh::common::EventCustom(type_v)
+        , super_secret(std::move(s))
+    {
+    }
+
+    std::string super_secret;
+    static constexpr std::int32_t type_v = 1;
+};
+
+TEST_CASE("WindowNone/Send & Poll Custom")
+{
+    meh::common::WindowNone window({});
+    meh::common::Event event;
+    CHECK(std::holds_alternative<meh::common::EventNone>(event));
+    CHECK(!window.poll(event));
+    CHECK(std::holds_alternative<meh::common::EventNone>(event));
+
+    window.send(std::make_unique<MyEvent>("Hello World"));
+    auto found_event = window.poll(event);
+    CHECK(found_event);
+    CHECK(std::holds_alternative<std::unique_ptr<meh::common::EventCustom>>(event));
+
+    auto custom_event = std::get<std::unique_ptr<meh::common::EventCustom>>(std::move(event));
+    auto* my_event = custom_event->as<MyEvent>();
+    REQUIRE(my_event);
+    CHECK(my_event->super_secret == "Hello World");
+
+    CHECK(!window.poll(event));
 }

--- a/MyApp/src/main.cpp
+++ b/MyApp/src/main.cpp
@@ -139,13 +139,25 @@ int main(int, char*[])
 
     loop = [&] {
         // Events
-        SDL_Event e;
-        while (SDL_PollEvent(&e) != 0)
+        meh::common::Event event;
+        while (window.poll(event))
         {
-            if (e.type == SDL_QUIT)
-                return false;
+            auto visitor = meh::common::overload{
+                [](meh::common::EventKey e) {
+                    spdlog::info("Key {} was {}", meh::common::keyToString(e.key), e.down ? "pressed" : "released");
+                },
+                [](meh::common::EventMouseButton e) {
+                    spdlog::info("Button {} was {}", meh::common::buttonToString(e.button), e.down ? "pressed" : "released");
+                },
+                [](meh::common::EventMouseMove e) {
+                    spdlog::info("Mouse moved to {},{}", e.x, e.y);
+                },
+                [](auto&&) {
+                    //unknown
+                }
+            };
 
-            ImGui_ImplSDL2_ProcessEvent(&e);
+            std::visit(visitor, event);
         }
 
         // Updates

--- a/cmake/FetchMagicEnum.cmake
+++ b/cmake/FetchMagicEnum.cmake
@@ -1,0 +1,19 @@
+if (TARGET magic_enum)
+    return()
+endif()
+
+include(SetSystemIncludes)
+
+if (NOT CPM_SOURCE_CACHE)
+    set(CPM_SOURCE_CACHE "${PROJECT_SOURCE_DIR}/../.cpmcache/")
+endif()
+
+CPMAddPackage(
+    NAME magic_enum
+    GITHUB_REPOSITORY Neargye/magic_enum
+    GIT_TAG v0.7.3
+    EXCLUDE_FROM_ALL "YES"
+)
+
+set_target_properties(magic_enum PROPERTIES FOLDER dependencies)
+set_target_includes_as_system(magic_enum)


### PR DESCRIPTION
Also updates MyApp to use the new input abstraction

- Adds `send` to all windows, to send events as a user of the window
- Adds `poll` to all windows, to receive events from the underlying implementaton, and the user
- Adds some tests for `WindowNone` using `send` and `poll` 
- Adds `EventCustom` which users can derive from to create their own events
- Adds `Key` and `Button` enums, which abstract over SDL
  - Adds `keyToString`, `keyFromString`, `buttonToString`, and `buttonFromString`, using the new dependency `MagicEnum`
- Suppresses `cppcoreguidelines-owning-memory`, `cppcoreguidelines-no-malloc`, and `cppcoreguidelines-pro-type-union-access` from clang-tidy due to having to use C libraries