### PR TITLE
Run workflows on the main branch

### DIFF
--- a/.github/workflows/CommonLib.yml
+++ b/.github/workflows/CommonLib.yml
@@ -1,6 +1,9 @@
 name: CommonLib
 
 on:
+  push:
+    branches:
+      - 'main'
   pull_request:
   release:
   

--- a/.github/workflows/MyApp.yml
+++ b/.github/workflows/MyApp.yml
@@ -1,6 +1,9 @@
 name: MyApp
 
 on:
+  push:
+    branches:
+      - 'main'
   pull_request:
   release:
 

--- a/.github/workflows/MyLib.yml
+++ b/.github/workflows/MyLib.yml
@@ -1,6 +1,9 @@
 name: MyLib
 
 on:
+  push:
+    branches:
+      - 'main'
   pull_request:
   release:
 


### PR DESCRIPTION
This fixes code coverage not updating as it never runs on the main branch. Also ensures the CI badges in the README remain accurate.

The linting workflow is unchanged, as it already ran on main