### PR TITLE
CommonLib: Added 'Input' class to track the state of the keyboard and mouse

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -23,6 +23,7 @@ Checks: '
     -cppcoreguidelines-owning-memory,
     -cppcoreguidelines-no-malloc,
     -cppcoreguidelines-pro-type-union-access,
+    -cppcoreguidelines-pro-bounds-constant-array-index,
 '
 
 WarningsAsErrors: '*'

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 build/
+build-*/
 workspace.code-workspace
 .vscode/
 .cpmcache/

--- a/CommonLib/src/CMakeLists.txt
+++ b/CommonLib/src/CMakeLists.txt
@@ -13,6 +13,8 @@ add_library(commonlib
     "CommonLib/Window/WindowNone.hpp"
     "CommonLib/Window/WindowNone.cpp"
 
+    "CommonLib/Input/Input.hpp"
+    "CommonLib/Input/Input.cpp"
     "CommonLib/Input/Events.hpp"
     "CommonLib/Input/Keys.hpp"
     "CommonLib/Input/Keys.cpp"

--- a/CommonLib/src/CommonLib/Input/Input.cpp
+++ b/CommonLib/src/CommonLib/Input/Input.cpp
@@ -1,0 +1,267 @@
+#include "Input.hpp"
+
+//SELF
+
+//LIBS
+
+//STD
+#include <cassert>
+
+using namespace meh::common;
+
+Input::Input()
+    : keys_last_frame{}
+    , keys_this_frame{}
+    , mouse_buttons_last_frame{}
+    , mouse_buttons_this_frame{}
+    , mouse_screen_pos_previous{ 0, 0 }
+    , mouse_screen_pos_current{ 0, 0 }
+{
+    keys_last_frame.fill(State::Unheld);
+    keys_this_frame.fill(State::Unheld);
+
+    mouse_buttons_last_frame.fill(State::Unheld);
+    mouse_buttons_this_frame.fill(State::Unheld);
+}
+
+void Input::process(const Event& event)
+{
+    const auto visitor = overload{
+        [this](const EventKey& e) {
+            if (e.key == Key::Unknown)
+                return; //todo: I'd rather not need to do this error checking
+
+            const auto key = static_cast<std::size_t>(e.key);
+
+            State state;
+
+            if (this->keys_last_frame[key] == State::JustPressed
+                || this->keys_last_frame[key] == State::HeldDown)
+            {
+                if (e.down)
+                    state = State::HeldDown;
+                else
+                    state = State::JustReleased;
+            }
+            else if (this->keys_last_frame[key] == State::JustReleased
+                     || this->keys_last_frame[key] == State::Unheld)
+            {
+                if (e.down)
+                    state = State::JustPressed;
+                else
+                    state = State::Unheld;
+            }
+            else
+            {
+                throw; //unreachable
+            }
+
+            /*if (this->keys_this_frame[key] != state)
+			{
+				spdlog::info("State of key {} was {}, but is now {}",
+					keyToString(e.key),
+					magic_enum::enum_name(this->keys_this_frame[key]).data(),
+					magic_enum::enum_name(state).data());
+			}*/
+            this->keys_this_frame[key] = state;
+        },
+        [this](const EventMouseButton& e) {
+            if (e.button == Button::Unknown)
+                return; //todo: I'd rather not need to do this error checking
+
+            const auto button = static_cast<std::size_t>(e.button);
+
+            State state;
+
+            if (this->mouse_buttons_last_frame[button] == State::JustPressed
+                || this->mouse_buttons_last_frame[button] == State::HeldDown)
+            {
+                if (e.down)
+                    state = State::HeldDown;
+                else
+                    state = State::JustReleased;
+            }
+            else if (this->mouse_buttons_last_frame[button] == State::JustReleased
+                     || this->mouse_buttons_last_frame[button] == State::Unheld)
+            {
+                if (e.down)
+                    state = State::JustPressed;
+                else
+                    state = State::Unheld;
+            }
+            else
+            {
+                throw; //unreachable, todo: change code so this isn't needed
+            }
+
+            /*if (this->mouse_buttons_this_frame[button] != state)
+			{
+				spdlog::info("State of button {} was {}, but is now {}",
+					buttonToString(e.button),
+					magic_enum::enum_name(this->mouse_buttons_this_frame[button]).data(),
+					magic_enum::enum_name(state).data());
+			}*/
+            this->mouse_buttons_this_frame[button] = state;
+        },
+        [this](const EventMouseMove& e) {
+            this->mouse_screen_pos_current = { e.x, e.y };
+        },
+        [](auto&&) {
+
+        }
+    };
+
+    std::visit(visitor, event);
+}
+
+void Input::prepare()
+{
+    for (size_t i = 0; i < keys_last_frame.size(); ++i)
+    {
+        keys_last_frame[i] = keys_this_frame[i];
+
+        // If the key was JustPressed or JustReleased then transition the current state to the full hold/release state
+        switch (keys_this_frame[i])
+        {
+        case State::Unheld:
+        case State::HeldDown:
+            break;
+        case State::JustPressed:
+            keys_this_frame[i] = State::HeldDown;
+            break;
+        case State::JustReleased:
+            keys_this_frame[i] = State::Unheld;
+            break;
+        default:
+            throw; // unreachable
+        }
+    }
+
+    for (size_t i = 0; i < mouse_buttons_last_frame.size(); ++i)
+    {
+        mouse_buttons_last_frame[i] = mouse_buttons_this_frame[i];
+
+        // If the button was JustPressed or JustReleased then transition the current state to the full hold/release state
+        switch (mouse_buttons_this_frame[i])
+        {
+        case State::Unheld:
+        case State::HeldDown:
+            break;
+        case State::JustPressed:
+            mouse_buttons_this_frame[i] = State::HeldDown;
+            break;
+        case State::JustReleased:
+            mouse_buttons_this_frame[i] = State::Unheld;
+            break;
+        default:
+            throw; // unreachable
+        }
+    }
+
+    mouse_screen_pos_previous = mouse_screen_pos_current;
+}
+
+bool Input::isKeyUp(Key key) const
+{
+    assert(key != Key::Unknown);
+    const auto k = static_cast<std::size_t>(key);
+    return (keys_this_frame[k] == State::Unheld || keys_this_frame[k] == State::JustReleased);
+}
+
+bool Input::isKeyReleased(Key key) const
+{
+    assert(key != Key::Unknown);
+    const auto k = static_cast<std::size_t>(key);
+    return (keys_this_frame[k] == State::JustReleased);
+}
+
+bool Input::isKeyPressed(Key key) const
+{
+    assert(key != Key::Unknown);
+    const auto k = static_cast<std::size_t>(key);
+    return (keys_this_frame[k] == State::JustPressed);
+}
+
+bool Input::isKeyDown(Key key) const
+{
+    assert(key != Key::Unknown);
+    const auto k = static_cast<std::size_t>(key);
+    return (keys_this_frame[k] == State::HeldDown || keys_this_frame[k] == State::JustPressed);
+}
+
+Input::State Input::getPreviousKeyState(Key key) const
+{
+    assert(key != Key::Unknown);
+    return keys_last_frame[static_cast<std::size_t>(key)];
+}
+
+Input::State Input::getCurrentKeyState(Key key) const
+{
+    assert(key != Key::Unknown);
+    return keys_this_frame[static_cast<std::size_t>(key)];
+}
+
+bool Input::isMouseButtonUp(Button button) const
+{
+    assert(button != Button::Unknown);
+    const auto b = static_cast<std::size_t>(button);
+    return (mouse_buttons_this_frame[b] == State::Unheld || mouse_buttons_this_frame[b] == State::JustReleased);
+}
+
+bool Input::isMouseButtonPressed(Button button) const
+{
+    assert(button != Button::Unknown);
+    const auto b = static_cast<std::size_t>(button);
+    return (mouse_buttons_this_frame[b] == State::JustPressed);
+}
+
+bool Input::isMouseButtonReleased(Button button) const
+{
+    assert(button != Button::Unknown);
+    const auto b = static_cast<std::size_t>(button);
+    return (mouse_buttons_this_frame[b] == State::JustReleased);
+}
+
+bool Input::isMouseButtonDown(Button button) const
+{
+    assert(button != Button::Unknown);
+    const auto b = static_cast<std::size_t>(button);
+    return (mouse_buttons_this_frame[b] == State::HeldDown || mouse_buttons_this_frame[b] == State::JustPressed);
+}
+
+Input::State Input::getPreviousButtonState(Button button) const
+{
+    assert(button != Button::Unknown);
+    return mouse_buttons_last_frame[static_cast<std::size_t>(button)];
+}
+
+Input::State Input::getCurrentButtonState(Button button) const
+{
+    assert(button != Button::Unknown);
+    return mouse_buttons_this_frame[static_cast<std::size_t>(button)];
+}
+
+bool meh::common::Input::hasMouseMoved() const
+{
+    //todo: if the screen moves...?
+    const auto delta = getMouseScreenPosDelta();
+    return delta.first == 0 && delta.second == 0;
+}
+
+std::pair<int, int> Input::getCurrentMouseScreenPos() const
+{
+    return mouse_screen_pos_current;
+}
+
+std::pair<int, int> Input::getPreviousMouseScreenPos() const
+{
+    return mouse_screen_pos_previous;
+}
+
+std::pair<int, int> Input::getMouseScreenPosDelta() const
+{
+    return {
+        mouse_screen_pos_previous.second - mouse_screen_pos_current.second,
+        mouse_screen_pos_previous.first - mouse_screen_pos_current.first
+    };
+}

--- a/CommonLib/src/CommonLib/Input/Input.hpp
+++ b/CommonLib/src/CommonLib/Input/Input.hpp
@@ -1,0 +1,76 @@
+#pragma once
+
+//SELF
+#include "CommonLib/Input/Keys.hpp"
+#include "CommonLib/Input/Events.hpp"
+
+//LIBS
+
+//STD
+#include <array>
+
+namespace meh::common
+{
+
+/* note: note reliable at low update rates. does not track multiple inputs of the same kind within a single frame */
+class Input
+{
+public:
+    enum class State : int
+    {
+        Unheld,
+        HeldDown,
+        JustReleased,
+        JustPressed,
+    };
+
+    Input();
+
+    /* Process an event, updating the input state */
+    void process(const Event& event);
+    /* Prepare for new input events by updating the previous input states */
+    void prepare();
+
+    /* Returns true if the key is Up regardless of its previous state */
+    [[nodiscard]] bool isKeyUp(Key key) const;
+    /* Returns true if the key is Down regardless of its previous state */
+    [[nodiscard]] bool isKeyDown(Key key) const;
+    /* Returns true if the key is Down when it was previously Up */
+    [[nodiscard]] bool isKeyReleased(Key key) const;
+    /* Returns true if the key is Up when it was previously Down */
+    [[nodiscard]] bool isKeyPressed(Key key) const;
+
+    [[nodiscard]] State getPreviousKeyState(Key key) const;
+    [[nodiscard]] State getCurrentKeyState(Key key) const;
+
+    /* Returns true if the button is Up regardless of its previous state */
+    [[nodiscard]] bool isMouseButtonUp(Button button) const;
+    /* Returns true if the button is Down regardless of its previous state */
+    [[nodiscard]] bool isMouseButtonDown(Button button) const;
+    /* Returns true if the button is Down when it was previously Up */
+    [[nodiscard]] bool isMouseButtonPressed(Button button) const;
+    /* Returns true if the button is Up when it was previously Down */
+    [[nodiscard]] bool isMouseButtonReleased(Button button) const;
+
+    [[nodiscard]] State getPreviousButtonState(Button button) const;
+    [[nodiscard]] State getCurrentButtonState(Button button) const;
+
+    [[nodiscard]] bool hasMouseMoved() const;
+    [[nodiscard]] std::pair<int, int> getCurrentMouseScreenPos() const;
+    [[nodiscard]] std::pair<int, int> getPreviousMouseScreenPos() const;
+    /* Returns the delta from the previous position to the current position. previous position + delta = current position */
+    [[nodiscard]] std::pair<int, int> getMouseScreenPosDelta() const;
+
+private:
+    std::array<State, static_cast<std::size_t>(Key::KeyCount)> keys_last_frame;
+    std::array<State, static_cast<std::size_t>(Key::KeyCount)> keys_this_frame;
+
+    std::array<State, static_cast<std::size_t>(Button::ButtonCount)> mouse_buttons_last_frame;
+    std::array<State, static_cast<std::size_t>(Button::ButtonCount)> mouse_buttons_this_frame;
+
+    //todo: don't use pair
+    std::pair<int, int> mouse_screen_pos_previous;
+    std::pair<int, int> mouse_screen_pos_current;
+};
+
+} // namespace meh::common

--- a/CommonLib/src/CommonLib/Input/Keys.hpp
+++ b/CommonLib/src/CommonLib/Input/Keys.hpp
@@ -10,7 +10,7 @@
 namespace meh::common
 {
 
-enum class Key
+enum class Key : int
 {
     Unknown = -1,
 
@@ -133,7 +133,7 @@ enum class Key
 Key keyFromString(const std::string& str);
 const char* keyToString(Key key);
 
-enum class Button
+enum class Button : int
 {
     Unknown = -1,
     Left,
@@ -142,7 +142,7 @@ enum class Button
     Button4,
     Button5,
 
-    KeyCount,
+    ButtonCount,
 };
 
 Button buttonFromString(const std::string& str);

--- a/MyApp/src/main.cpp
+++ b/MyApp/src/main.cpp
@@ -21,6 +21,7 @@
 
 #include <MyLib/Library.hpp>
 #include <CommonLib/Window/WindowSDL.hpp>
+#include <CommonLib/Input/Input.hpp>
 
 #include <imgui.h>
 #include <backends/imgui_impl_sdl.h>
@@ -137,28 +138,47 @@ int main(int, char*[])
 
     bool show_demo_window = true;
 
+    meh::common::Input input;
+
     loop = [&] {
         // Events
         meh::common::Event event;
+        input.prepare();
         while (window.poll(event))
         {
             auto visitor = meh::common::overload{
-                [](meh::common::EventKey e) {
-                    spdlog::info("Key {} was {}", meh::common::keyToString(e.key), e.down ? "pressed" : "released");
+                [](meh::common::EventKey) {
+                    //spdlog::info("Key {} was {}", meh::common::keyToString(e.key), e.down ? "pressed" : "released");
                 },
-                [](meh::common::EventMouseButton e) {
-                    spdlog::info("Button {} was {}", meh::common::buttonToString(e.button), e.down ? "pressed" : "released");
+                [](meh::common::EventMouseButton) {
+                    //spdlog::info("Button {} was {}", meh::common::buttonToString(e.button), e.down ? "pressed" : "released");
                 },
-                [](meh::common::EventMouseMove e) {
-                    spdlog::info("Mouse moved to {},{}", e.x, e.y);
+                [](meh::common::EventMouseMove) {
+                    //spdlog::info("Mouse moved to {},{}", e.x, e.y);
                 },
                 [](auto&&) {
                     //unknown
                 }
             };
 
+            input.process(event);
             std::visit(visitor, event);
         }
+
+        if (input.isKeyPressed(meh::common::Key::F1))
+            spdlog::info("F1 Pressed");
+
+        if (input.isKeyPressed(meh::common::Key::W))
+            spdlog::info("W Pressed");
+
+        if (input.isKeyDown(meh::common::Key::W))
+            spdlog::info("W Held");
+
+        if (input.isKeyReleased(meh::common::Key::W))
+            spdlog::info("W Released");
+
+        if (input.isMouseButtonReleased(meh::common::Button::Left))
+            spdlog::info("MB1 Released");
 
         // Updates
         ImGui_ImplOpenGL3_NewFrame();

--- a/cmake/FetchASIO.cmake
+++ b/cmake/FetchASIO.cmake
@@ -1,4 +1,12 @@
+if (TARGET asio)
+    return()
+endif()
+
 include(SetSystemIncludes)
+
+if (NOT CPM_SOURCE_CACHE)
+    set(CPM_SOURCE_CACHE "${PROJECT_SOURCE_DIR}/../.cpmcache/")
+endif()
 
 CPMAddPackage(
         NAME asio

--- a/cmake/FetchGLM.cmake
+++ b/cmake/FetchGLM.cmake
@@ -1,4 +1,12 @@
+if (TARGET glm)
+    return()
+endif()
+
 include(SetSystemIncludes)
+
+if (NOT CPM_SOURCE_CACHE)
+    set(CPM_SOURCE_CACHE "${PROJECT_SOURCE_DIR}/../.cpmcache/")
+endif()
 
 CPMAddPackage(
     NAME glm


### PR DESCRIPTION
### Requires PR https://github.com/Zephilinox/Meh/pull/5

- Adds `Input` class, which when fed events from the window, will keep track of the state of the keyboard and mouse for that frame.
- Disables `cppcoreguidelines-pro-bounds-constant-array-index` clang-tidy check since it's unhelpfully moaning :b
- Adds guard and cpm cache directory to `FetchASIO` and `FetchGLM`
- Changes `main.cpp` for `MyApp` to use the added `Input` class