### PR TITLE
CommonLib: Add Signals

### DIFF
--- a/CommonLib/benchmarks/CMakeLists.txt
+++ b/CommonLib/benchmarks/CMakeLists.txt
@@ -3,6 +3,7 @@ include(ConfigureTarget)
 include(CompilerWarnings)
 
 add_executable(commonlib_benchmarks "main.cpp"
+    "Signal.bench.hpp"
 )
 
 configure_target(commonlib_benchmarks "${COMMONLIB_CODE_COVERAGE}")

--- a/CommonLib/benchmarks/Signal.bench.hpp
+++ b/CommonLib/benchmarks/Signal.bench.hpp
@@ -1,0 +1,130 @@
+#pragma once
+
+//SELF
+#include "CommonLib/Signal/Signal.hpp"
+
+//LIBS
+#include <benchmark/benchmark.h>
+
+//STD
+#include <memory>
+
+struct Base
+{
+    virtual void do_thing(int) = 0;
+    virtual ~Base() = default;
+};
+
+struct Derived : public Base
+{
+    void do_thing(int a) override
+    {
+        if (a != 5)
+            throw;
+    }
+};
+
+static void bench_virtual_int(benchmark::State& state)
+{
+    std::unique_ptr<Base> thing;
+    thing = std::make_unique<Derived>();
+
+    for ([[maybe_unused]] auto _ : state) // NOLINT(clang-analyzer-deadcode.DeadStores)
+    {
+        thing->do_thing(5);
+    }
+
+    state.SetItemsProcessed(static_cast<std::int64_t>(state.iterations()));
+}
+BENCHMARK(bench_virtual_int);
+
+static void bench_signal_emit_int_1_slot(benchmark::State& state)
+{
+    meh::common::Signal<int> signal;
+    signal.connect([](int a) {
+        if (a != 5)
+            throw;
+    });
+
+    for ([[maybe_unused]] auto _ : state) // NOLINT(clang-analyzer-deadcode.DeadStores)
+    {
+        signal.emit(5);
+    }
+
+    state.SetItemsProcessed(static_cast<std::int64_t>(state.iterations()));
+}
+BENCHMARK(bench_signal_emit_int_1_slot);
+
+static void bench_signal_emit_int_100_slots(benchmark::State& state)
+{
+    meh::common::Signal<int> signal;
+    for (int i = 0; i < 100; ++i)
+    {
+        signal.connect([](int a) {
+            if (a != 5)
+                throw;
+        });
+    }
+
+    for ([[maybe_unused]] auto _ : state) // NOLINT(clang-analyzer-deadcode.DeadStores)
+    {
+        signal.emit(5);
+    }
+
+    state.SetItemsProcessed(static_cast<std::int64_t>(state.iterations() * 100));
+}
+BENCHMARK(bench_signal_emit_int_100_slots);
+
+static void bench_signal_emit_int_10000_slots(benchmark::State& state)
+{
+    meh::common::Signal<int> signal;
+    for (int i = 0; i < 10000; ++i)
+    {
+        signal.connect([](int a) {
+            if (a != 5)
+                throw;
+        });
+    }
+
+    for ([[maybe_unused]] auto _ : state) // NOLINT(clang-analyzer-deadcode.DeadStores)
+    {
+        signal.emit(5);
+    }
+
+    state.SetItemsProcessed(static_cast<std::int64_t>(state.iterations() * 10000));
+}
+BENCHMARK(bench_signal_emit_int_10000_slots);
+
+static void bench_signal_connect(benchmark::State& state)
+{
+    meh::common::Signal<int> signal;
+    auto lambda = [](int a) {
+        if (a != 5)
+            throw;
+    };
+
+    for ([[maybe_unused]] auto _ : state) // NOLINT(clang-analyzer-deadcode.DeadStores)
+    {
+        signal.connect(lambda);
+    }
+
+    state.SetItemsProcessed(static_cast<std::int64_t>(state.iterations()));
+}
+BENCHMARK(bench_signal_connect);
+
+static void bench_signal_disconnect(benchmark::State& state)
+{
+    meh::common::Signal<int> signal;
+    auto lambda = [](int a) {
+        if (a != 5)
+            throw;
+    };
+
+    for ([[maybe_unused]] auto _ : state) // NOLINT(clang-analyzer-deadcode.DeadStores)
+    {
+        meh::common::ManagedConnection mc = signal.connect(lambda);
+    }
+
+    state.SetItemsProcessed(static_cast<std::int64_t>(state.iterations()));
+}
+BENCHMARK(bench_signal_disconnect);

--- a/CommonLib/benchmarks/main.cpp
+++ b/CommonLib/benchmarks/main.cpp
@@ -1,7 +1,10 @@
 //SELF
+#include "Signal.bench.hpp"
 
 //LIBS
 #include <benchmark/benchmark.h>
+
+//STD
 
 auto main(int argc, char** argv) -> int
 {

--- a/CommonLib/src/CMakeLists.txt
+++ b/CommonLib/src/CMakeLists.txt
@@ -19,6 +19,12 @@ add_library(commonlib
     "CommonLib/Input/Keys.hpp"
     "CommonLib/Input/Keys.cpp"
     "CommonLib/Input/KeysSDL.hpp"
+
+    "CommonLib/Signal/Connection.hpp"
+    "CommonLib/Signal/Connection.cpp"
+    "CommonLib/Signal/Disconnector.hpp"
+    "CommonLib/Signal/Signal.hpp"
+    "CommonLib/Signal/Slot.hpp"
 )
 add_library(commonlib::commonlib ALIAS commonlib)
 

--- a/CommonLib/src/CommonLib/Signal/Connection.cpp
+++ b/CommonLib/src/CommonLib/Signal/Connection.cpp
@@ -1,0 +1,82 @@
+#include "Connection.hpp"
+
+//SELF
+#include "Disconnector.hpp"
+
+//LIBS
+
+//STD
+
+using namespace meh::common;
+
+Connection::operator bool() const noexcept
+{
+    return slot_id != 0 && !weak_disconnector.expired();
+}
+
+Connection::Connection(Connection&& c) noexcept
+    : weak_disconnector(std::move(c.weak_disconnector))
+    , slot_id(c.slot_id)
+{
+    c.slot_id = 0;
+}
+
+Connection& Connection::operator=(Connection&& c) noexcept
+{
+    if (this == &c)
+        return *this;
+
+    weak_disconnector = std::move(c.weak_disconnector);
+    slot_id = c.slot_id;
+    c.slot_id = 0;
+
+    return *this;
+}
+
+bool Connection::disconnect()
+{
+    auto disconnector = weak_disconnector.lock();
+    if (!disconnector)
+    {
+        weak_disconnector.reset();
+        slot_id = 0;
+        return false;
+    }
+
+    const bool was_connected = disconnector->disconnect(*this);
+    weak_disconnector.reset();
+    slot_id = 0;
+    return was_connected;
+}
+
+//private
+Connection::Connection(std::weak_ptr<Disconnector> dc, unsigned id) noexcept
+    : weak_disconnector(std::move(dc))
+    , slot_id(id)
+{
+}
+
+ManagedConnection::ManagedConnection(const Connection& c)
+    : Connection(c)
+{
+}
+
+ManagedConnection& ManagedConnection::operator=(ManagedConnection&& c) noexcept
+{
+    //Don't disconnect if we're moving ourselves in to ourselves.
+    if (this == &c)
+        return *this;
+
+    //Disconnect whatever connection we may currently be managing
+    disconnect();
+
+    //Call base move assignment operator
+    Connection::operator=(std::move(c));
+
+    return *this;
+}
+
+ManagedConnection::~ManagedConnection() noexcept
+{
+    disconnect();
+}

--- a/CommonLib/src/CommonLib/Signal/Connection.hpp
+++ b/CommonLib/src/CommonLib/Signal/Connection.hpp
@@ -1,0 +1,89 @@
+#pragma once
+
+//SELF
+
+//LIBS
+
+//STD
+#include <functional>
+#include <memory>
+
+namespace meh::common
+{
+
+template <typename... Args>
+class Signal;
+
+class Disconnector;
+
+/*
+ * Connection is returned by signal.connect()
+ * Use it to control disconnecting your function from the signal
+ * Similar to a raw pointer. if you do not manually disconnect, the connection will `leak`
+ * A leaked connection is acceptable as long as the connected function (Slot) outlives the Signal
+ *    e.g. a member function slot connected to a member variable signal
+ */
+class Connection
+{
+public:
+    Connection() noexcept = default;
+    Connection(const Connection& c) = default;
+    Connection(Connection&& c) noexcept;
+    Connection& operator=(const Connection& c) = default;
+    Connection& operator=(Connection&& c) noexcept;
+    virtual ~Connection() noexcept = default;
+
+    //Check to see if the Connection is still valid
+    operator bool() const noexcept;
+
+    //Ensures both Connections are connected to the same Signal and referring to the same function
+    //Might return false if both connections are invalid, depending on what made them invalid.
+    friend bool operator==(const Connection& lhs, const Connection& rhs) noexcept
+    {
+        return lhs.slot_id == rhs.slot_id
+               && lhs.weak_disconnector.lock().get() == rhs.weak_disconnector.lock().get();
+    }
+
+    friend bool operator!=(const Connection& lhs, const Connection& rhs) noexcept
+    {
+        return !operator==(lhs, rhs);
+    }
+
+    //Returns true if disconnection was successful
+    //False if it was not, or if it's already disconnected
+    bool disconnect();
+
+private:
+    //Signal needs to be able to create Connection with specific params
+    //Clients should not be able to, as it means they can do random shit to a signal
+    //Note: this means that a Signal<int> is a friend of Connection<bool>
+    //But this shouldn't be a problem, since it's created based on the Signal <Args...>
+    template <typename...>
+    friend class Signal;
+
+    //Only meant to be accessed by Signal
+    Connection(std::weak_ptr<Disconnector> dc, unsigned id) noexcept;
+
+    std::weak_ptr<Disconnector> weak_disconnector;
+    unsigned slot_id = 0;
+};
+
+/*
+ * Just a wrapper around Connection with RAII semantics. Automatically disconnects on destruction
+ * Similar behaviour to std::shared_ptr
+ */
+class ManagedConnection final : public Connection
+{
+public:
+    ManagedConnection() noexcept = default;
+    explicit(false) ManagedConnection(const Connection& c);
+
+    ManagedConnection(const ManagedConnection&) = default;
+    ManagedConnection(ManagedConnection&& c) noexcept = default;
+    ManagedConnection& operator=(const ManagedConnection& c) = default;
+    ManagedConnection& operator=(ManagedConnection&& c) noexcept;
+
+    ~ManagedConnection() noexcept;
+};
+
+} // namespace meh::common

--- a/CommonLib/src/CommonLib/Signal/Disconnector.hpp
+++ b/CommonLib/src/CommonLib/Signal/Disconnector.hpp
@@ -1,0 +1,46 @@
+#pragma once
+
+//SELF
+
+//LIBS
+
+//STD
+
+namespace meh::common
+{
+
+class Connection;
+
+/*
+Type Erasure:
+Signal defines a derived class of Disconnector with appropriate template types
+Connection has a weak_ptr to Disconnector, owned by the Signal.
+Disconnector is actually a SignalDisconnector which has a raw ptr to Signal
+When connection calls disconnector->disconnect(), it calls the derived one that signal passed in, which in turn calls signal->disconnect(connection)
+This means that Connection and ManagedConnection do not need to be templated, so this code is valid
+
+	Signal<int> signal;
+	ManagedConnection c = signal.connect([](int i)
+	{
+	std::cout << i;
+	});
+
+instead of this code, which requires <int> for ManagedConnection
+
+	Signal<int> signal;
+	ManagedConnection<int> c = signal.connect([](int i)
+	{
+	std::cout << i;
+	});
+
+Clients no longer need to care about what type signal is when storing connections, yay!
+*/
+
+class Disconnector
+{
+public:
+    virtual ~Disconnector() noexcept = default;
+    virtual bool disconnect(Connection& c) = 0;
+};
+
+} // namespace meh::common

--- a/CommonLib/src/CommonLib/Signal/Signal.hpp
+++ b/CommonLib/src/CommonLib/Signal/Signal.hpp
@@ -1,0 +1,149 @@
+#pragma once
+
+//SELF
+#include "CommonLib/Signal/Connection.hpp"
+#include "CommonLib/Signal/Disconnector.hpp"
+#include "CommonLib/Signal/Slot.hpp"
+
+//LIBS
+
+//STD
+#include <vector>
+#include <stdexcept>
+
+/*
+ * Args determines the arguments that the signal can emit
+ *     which is also the parameters functions must accept
+ * Automatically invalidates all Connections created by calling connect()
+ */
+namespace meh::common
+{
+
+template <typename... Args>
+class Signal
+{
+public:
+    using FunctionType = std::function<void(Args...)>;
+
+    Signal() noexcept
+        : dc(std::make_shared<SignalDisconnector<Args...>>(this))
+    {
+    }
+
+    //Connect to a non-member function/lambda/etc.
+    //Connecting to an invalid function, such as a nullptr, will throw an exception.
+    Connection connect(FunctionType&& function)
+    {
+        if (!function)
+            throw std::runtime_error("Invalid function");
+
+        slot_id_counter++;
+        slots.emplace_back(Connection(dc, slot_id_counter), std::forward<FunctionType>(function));
+        return slots.back().connection;
+    }
+
+    //Connect to a member function.
+    //Undefined behaviour if the object instance is destroyed before it is disconnected.
+    //You should pass a ManagedConnection to the object instance for it to store.
+    template <typename T>
+    Connection connect(T* instance, void (T::*function)(Args...))
+    {
+        auto wrapper = [=](Args... args) {
+            (instance->*function)(std::forward<Args>(args)...);
+        };
+
+        return connect(std::move(wrapper));
+    }
+
+    // Connect to a const member function.
+    // Undefined behaviour if the object instance is destroyed before it is disconnected.
+    // You should pass a ManagedConnection to the object instance for it to store.
+    template <typename T>
+    Connection connect(T* instance, void (T::*function)(Args...) const)
+    {
+        auto wrapper = [=](Args... args) {
+            (instance->*function)(std::forward<Args>(args)...);
+        };
+
+        return connect(std::move(wrapper));
+    }
+
+    // True if disconnect was successful.
+    // False if the Connection is invalid or if no disconnection occurred.
+    // Resets the Connection passed in, so that it's no longer valid.
+    bool disconnect(Connection& connection)
+    {
+        if (!connection)
+            return false;
+
+        bool valid_disconnect = false;
+
+        std::erase_if(slots, [&](const auto& slot) {
+            if (connection == slot.connection)
+            {
+                connection = Connection();
+                valid_disconnect = true;
+                return true;
+            }
+
+            return false;
+        });
+
+        return valid_disconnect;
+    }
+
+    // Calls all functions connected to the signal using the passed params
+    void emit(Args... args)
+    {
+        for (const auto& s : slots)
+        {
+            // Guaranteed valid from connect();
+            if (s.function)
+                s.function(args...);
+        }
+    }
+
+private:
+    /*
+		Part 2 of type erasure :D
+		SignalDisconnector stores a raw pointer to signal
+		signal stores a shared_ptr to the disconnector
+
+		This means that the raw pointer should always point to signal correctly
+		since signal only shares weak_ptrs of the disconnector, not ref-counted shared_ptr's.
+
+		If the signal is destroyed so is the SignalDisconnector
+		thus invalidating all weak_ptr's held in any Connections for the signal
+	*/
+    template <typename... Args2>
+    class SignalDisconnector : public Disconnector
+    {
+    public:
+        SignalDisconnector(Signal<Args2...>* s) noexcept
+            : signal(s)
+        {
+        }
+
+        bool disconnect(Connection& c) final
+        {
+            if (signal)
+                return signal->disconnect(c);
+
+            return false;
+        }
+
+        Signal<Args2...>* signal;
+    };
+
+    // 0 is invalid(like a nullptr), anything higher is fine.
+    unsigned slot_id_counter = 0;
+
+    // We own this, only share weak_ptrs so that connections
+    //     know when this signal is destroyed
+    std::shared_ptr<SignalDisconnector<Args...>> dc;
+
+    // Store all the functions and connections
+    std::vector<Slot<Args...>> slots;
+};
+
+} // namespace meh::common

--- a/CommonLib/src/CommonLib/Signal/Slot.hpp
+++ b/CommonLib/src/CommonLib/Signal/Slot.hpp
@@ -1,0 +1,34 @@
+#pragma once
+
+//SELF
+
+//LIBS
+
+//STD
+#include <functional>
+
+namespace meh::common
+{
+
+template <typename... Args>
+class Signal;
+
+class Connection;
+
+/*
+The Slot struct is just a replacement for std::pair.
+I prefer to refer to named variables rather than first and second.
+*/
+template <typename... Args>
+struct Slot
+{
+    Slot(Connection c, std::function<void(Args...)> f)
+        : connection(c)
+        , function(f)
+    {
+    }
+
+    Connection connection;
+    std::function<void(Args...)> function;
+};
+} // namespace meh::common

--- a/CommonLib/tests/CMakeLists.txt
+++ b/CommonLib/tests/CMakeLists.txt
@@ -5,6 +5,7 @@ include(CompilerWarnings)
 add_executable(commonlib_tests
     "main.cpp"
     "commonlib.hpp"
+    "Signal.test.hpp"
 )
 
 configure_target(commonlib_tests ${COMMONLIB_CODE_COVERAGE})

--- a/CommonLib/tests/Signal.test.hpp
+++ b/CommonLib/tests/Signal.test.hpp
@@ -1,0 +1,301 @@
+//SELF
+#include "CommonLib/Signal/Signal.hpp"
+
+//LIBS
+#include <doctest/doctest.h>
+
+//STD
+
+struct MyClass
+{
+    MyClass(int* c)
+        : count(c)
+    {
+    }
+
+    void do_thing(int a)
+    {
+        CHECK(a == 5);
+        (*count)++;
+    }
+
+    int* count;
+};
+
+TEST_CASE("Signal/Emit int")
+{
+    meh::common::Signal<int> signal;
+    unsigned int count = 0;
+
+    signal.connect([&count](int a) {
+        CHECK(a == 5);
+        count++;
+    });
+
+    signal.emit(5);
+    CHECK(count == 1);
+}
+
+TEST_CASE("Signal/Emit const int&")
+{
+    meh::common::Signal<const int&> signal;
+    unsigned int count = 0;
+
+    signal.connect([&count](int a) {
+        CHECK(a == 5);
+        count++;
+    });
+
+    signal.emit(5);
+    CHECK(count == 1);
+}
+
+TEST_CASE("Signal/Emit int&")
+{
+    meh::common::Signal<int&> signal;
+    int count = 0;
+
+    signal.connect([](int& a) {
+        CHECK(a == 0);
+        a++;
+    });
+
+    signal.emit(count);
+    CHECK(count == 1);
+}
+
+TEST_CASE("Signal/Emit member function")
+{
+    {
+        meh::common::Signal<int> signal;
+        int count = 0;
+        MyClass myclass(&count);
+
+        signal.connect(&myclass, &MyClass::do_thing);
+
+        signal.emit(5);
+        CHECK(count == 1);
+    }
+}
+
+TEST_CASE("Signal/Connection")
+{
+    meh::common::Signal<int> signal;
+    unsigned int count = 0;
+
+    auto lambda = [&count](int a) {
+        CHECK(a == 5);
+        count++;
+    };
+
+    {
+        // can connect and disconnect
+        auto dc = signal.connect(lambda);
+        CHECK(dc);
+
+        CHECK(dc.disconnect());
+        CHECK(!dc.disconnect());
+        CHECK(!dc);
+    }
+
+    {
+        // two can connect, disconnect, and be different while valid, and the same when invalid
+        auto dc = signal.connect(lambda);
+        auto dc2 = signal.connect(lambda);
+        CHECK_NE(dc, dc2);
+        CHECK(dc);
+        CHECK(dc2);
+        CHECK(dc.disconnect());
+        CHECK(dc2.disconnect());
+        CHECK(!dc);
+        CHECK(!dc2);
+        CHECK_EQ(dc, dc2);
+    }
+
+    {
+        // one can connect and then move, and be different while valid, and the same when invalid
+        auto dc = signal.connect(lambda);
+        auto dc2 = std::move(dc);
+        CHECK_NE(dc, dc2);
+        CHECK(!dc);
+        CHECK(!dc.disconnect());
+        CHECK(dc2);
+        CHECK(dc2.disconnect());
+        CHECK(!dc2);
+        CHECK_EQ(dc, dc2);
+    }
+
+    {
+        // one can connect and then be copied, be the same while valid, and the same when invalid, and they can both disconnect safely
+        auto dc3 = signal.connect(lambda);
+        auto dc4 = dc3;
+        CHECK(dc3);
+        CHECK(dc4);
+        CHECK_EQ(dc3, dc4);
+        CHECK(dc3.disconnect());
+        CHECK_NE(dc3, dc4);
+        CHECK(!dc4.disconnect());
+        CHECK_EQ(dc3, dc4);
+    }
+
+    // nothing is emitted
+    signal.emit(0);
+    signal.emit(0);
+    signal.emit(0);
+    CHECK(count == 0);
+}
+
+TEST_CASE("Signal/ManagedConnection")
+{
+    meh::common::Signal<int> signal;
+    unsigned int count = 0;
+
+    auto lambda = [&count](int a) {
+        CHECK(a == 5);
+        count++;
+    };
+
+    {
+        // can connect and disconnect
+        meh::common::ManagedConnection mc = signal.connect(lambda);
+        CHECK(mc);
+
+        CHECK(mc.disconnect());
+        CHECK(!mc.disconnect());
+        CHECK(!mc);
+
+        signal.emit(0);
+        CHECK(count == 0);
+    }
+
+    {
+        // can connect and then disconnect via destruction
+        auto mc = std::make_unique<meh::common::ManagedConnection>(signal.connect(lambda));
+        CHECK(*mc);
+
+        mc.reset();
+
+        signal.emit(0);
+        CHECK(count == 0);
+    }
+
+    {
+        // can copy
+        meh::common::ManagedConnection mc = signal.connect(lambda);
+        auto mc2 = mc;
+        CHECK(mc);
+        CHECK(mc2);
+        CHECK_EQ(mc, mc2);
+        CHECK(mc.disconnect());
+        CHECK(!mc.disconnect());
+        CHECK(!mc);
+        CHECK_NE(mc, mc2);
+        CHECK(!mc2.disconnect());
+        CHECK(!mc2.disconnect());
+        CHECK(!mc2);
+        CHECK_EQ(mc, mc2);
+
+        signal.emit(0);
+        CHECK(count == 0);
+    }
+
+    {
+        // can move and manually disconnect
+        meh::common::ManagedConnection mc = signal.connect(lambda);
+        auto mc2 = std::move(mc);
+        CHECK(!mc);
+        CHECK(mc2);
+        CHECK_NE(mc, mc2);
+        CHECK(!mc.disconnect());
+        CHECK(!mc.disconnect());
+        CHECK(!mc);
+        CHECK_NE(mc, mc2);
+        CHECK(mc2.disconnect());
+        CHECK(!mc2.disconnect());
+        CHECK(!mc2);
+        CHECK_EQ(mc, mc2);
+
+        signal.emit(0);
+        CHECK(count == 0);
+    }
+
+    {
+        // can move and automatically disconnect
+        {
+            meh::common::ManagedConnection mc = signal.connect(lambda);
+            auto mc2 = std::move(mc);
+            CHECK(!mc);
+            CHECK(mc2);
+            CHECK_NE(mc, mc2);
+            CHECK(!mc.disconnect());
+            CHECK(!mc.disconnect());
+            CHECK(!mc);
+            CHECK_NE(mc, mc2);
+        }
+
+        signal.emit(0);
+        CHECK(count == 0);
+    }
+
+    {
+        // disconnects existing connection before taking on new connection. can be created from Connection
+        {
+            meh::common::ManagedConnection mc = signal.connect(lambda);
+            mc = signal.connect(lambda);
+            mc = signal.connect(lambda);
+            signal.emit(5);
+            CHECK(count == 1);
+        }
+
+        count = 0;
+        signal.emit(0);
+        CHECK(count == 0);
+    }
+
+    signal.emit(0);
+    signal.emit(0);
+    signal.emit(0);
+    CHECK(count == 0);
+}
+
+TEST_CASE("Signal/Destroyed while Connection held")
+{
+    meh::common::Connection c;
+
+    {
+        meh::common::Signal<int> signal;
+        unsigned int count = 0;
+
+        c = signal.connect([&count](int a) {
+            CHECK(a == 5);
+            count++;
+        });
+
+        signal.emit(5);
+        CHECK(count == 1);
+    }
+
+    CHECK(!c);
+    CHECK(!c.disconnect());
+}
+
+TEST_CASE("Signal/Destroyed while ManagedConnection held")
+{
+    meh::common::ManagedConnection mc;
+
+    {
+        meh::common::Signal<int> signal;
+        unsigned int count = 0;
+
+        mc = signal.connect([&count](int a) {
+            CHECK(a == 5);
+            count++;
+        });
+
+        signal.emit(5);
+        CHECK(count == 1);
+    }
+
+    CHECK(!mc);
+    CHECK(!mc.disconnect());
+}

--- a/CommonLib/tests/main.cpp
+++ b/CommonLib/tests/main.cpp
@@ -1,5 +1,6 @@
 //SELF
 #include "commonlib.hpp"
+#include "Signal.test.hpp"
 
 //LIBS
 #define DOCTEST_CONFIG_IMPLEMENT


### PR DESCRIPTION
Adds a `Signals & Slots` implementation. It's an alternative to the classic observer pattern.

- This implementation is not thread safe, make sure all access to a signal is single-threaded
- Tests exist and are passing. not exhaustive, but should be good enough
- Benchmarks exist and show that it's about as performant as a virtual function call, so performance shouldn't be a concern.
- It can't handle return values
- It can handle member functions
- `Connection` is similar to a raw pointer, but it's okay to leak it when the slot (thing passed to `signal.connect`) has a lifetime equal to or greater than the lifetime of the signal (i.e a lambda that it owns is always safe, you just won't be able to remove it from the signal without destroying the signal itself)
- `ManagedConnection` will clean up for you when ANY of the managed connections go out of scope (no reference counting, but no unique ownership of the connection either)

Example:

```
meh::common::Signal<int> signal;
meh::common::ManagedConnection mc = signal.connect([](int number) { std::cout << number << "\n"; });
signal.emit(5); // prints "5"
```